### PR TITLE
not use zstd in badger

### DIFF
--- a/database/document/document.go
+++ b/database/document/document.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/badger/v3/options"
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/engine/badgerengine"
 	"github.com/pingcap/log"
@@ -22,7 +21,6 @@ func Init(cfg *config.Config) {
 	dataPath := path.Join(cfg.Storage.Path, "docdb")
 	l, _ := simpleLogger(&cfg.Log)
 	opts := badger.DefaultOptions(dataPath).
-		WithCompression(options.ZSTD).
 		WithZSTDCompressionLevel(3).
 		WithBlockSize(8 * 1024).
 		WithValueThreshold(128 * 1024).


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

zstd is useless now, and it will consume too much memory when GC. Use default `snappy` compression algorithm is better.