### PR TITLE
*: add test for conprof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 data
 bin
 log
+*.log
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 PACKAGE_LIST  := go list ./...| grep -E "github.com/pingcap/ng_monitoring/"
+PACKAGE_LIST_TESTS  := go list ./... | grep -E "github.com/pingcap/ng_monitoring/"
 PACKAGES  ?= $$($(PACKAGE_LIST))
+PACKAGES_TESTS ?= $$($(PACKAGE_LIST_TESTS))
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/ng_monitoring/||'
 FILES     := $$(find $$($(PACKAGE_DIRECTORIES)) -name "*.go")
 FAIL_ON_STDOUT := awk '{ print } END { if (NR > 0) { exit 1 } }'
 
 GO              := GO111MODULE=on go
 GOBUILD         := $(GO) build
+GOTEST          := $(GO) test -p 8
+
 
 
 default:
@@ -16,3 +20,8 @@ fmt:
 	@echo "gofmt (simplify)"
 	@gofmt -s -l -w . 2>&1 | $(FAIL_ON_STDOUT)
 	@gofmt -s -l -w $(FILES) 2>&1 | $(FAIL_ON_STDOUT)
+
+test:
+	@echo "Running test"
+	@export log_level=info; export TZ='Asia/Shanghai'; \
+	$(GOTEST) -cover $(PACKAGES_TESTS) -coverprofile=coverage.txt

--- a/component/conprof/README.md
+++ b/component/conprof/README.md
@@ -5,14 +5,14 @@
 curl http://0.0.0.0:12020/config
 
 # modify config
-curl -X POST -d '{"continuous-profiling": {"enable": false,"profile-seconds":6,"interval-seconds":11}}' http://0.0.0.0:12020/config
+curl -X POST -d '{"continuous_profiling": {"enable": false,"profile_seconds":6,"interval_seconds":11}}' http://0.0.0.0:12020/config
 
 # estimate size profile data size
-curl http://0.0.0.0:12020/continuous_profiling/estimate-size\?days\=3
+curl http://0.0.0.0:12020/continuous_profiling/estimate_size\?days\=3
 
 # query group profiles
 
-curl "http://0.0.0.0:12020/continuous_profiling/group_profiles?begin_time=1634836900&end_time=1634836910"
+curl "http://0.0.0.0:12020/continuous_profiling/group_profiles?begin_time=1634836900&end_time=1654836910"
 [
     {
         "ts": 1634836900,

--- a/component/conprof/http/api_test.go
+++ b/component/conprof/http/api_test.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"github.com/genjidb/genji"
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/ng_monitoring/component/conprof"
+	"github.com/pingcap/ng_monitoring/component/topology"
+	"github.com/pingcap/ng_monitoring/config"
+	"github.com/pingcap/ng_monitoring/utils/testutil"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+)
+
+type testSuite struct {
+	tmpDir string
+	db     *genji.DB
+}
+
+func (ts *testSuite) setup(t *testing.T) {
+	var err error
+	ts.tmpDir, err = ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	ts.db = testutil.NewGenjiDB(t, ts.tmpDir)
+	cfg := config.GetDefaultConfig()
+	cfg.ContinueProfiling.Enable = true
+	cfg.ContinueProfiling.ProfileSeconds = 1
+	cfg.ContinueProfiling.IntervalSeconds = 1
+	config.StoreGlobalConfig(&cfg)
+}
+
+func (ts *testSuite) close(t *testing.T) {
+	err := ts.db.Close()
+	err = os.RemoveAll(ts.tmpDir)
+	require.NoError(t, err)
+}
+
+func TestAPI(t *testing.T) {
+	ts := testSuite{}
+	ts.setup(t)
+	defer ts.close(t)
+
+	topoSubScribe := make(topology.Subscriber)
+	err := conprof.Init(ts.db, topoSubScribe)
+	require.NoError(t, err)
+	defer conprof.Stop()
+
+	httpAddr := setupHTTPService(t)
+
+	mockServer := testutil.CreateMockProfileServer(t)
+	defer mockServer.Stop(t)
+
+	addr := mockServer.Addr
+	port := mockServer.Port
+	components := []topology.Component{
+		{Name: topology.ComponentPD, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiDB, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiKV, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiFlash, IP: addr, Port: port, StatusPort: port},
+	}
+	// notify topology
+	topoSubScribe <- components
+
+	// wait for scrape finish
+	//time.Sleep(time.Millisecond * 1500)
+
+	// test for group_profiles api
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/group_profiles")
+	require.NoError(t, err)
+	require.Equal(t, 503, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"message":"need param begin_time","status":"error"}`, string(body))
+}
+
+func setupHTTPService(t *testing.T) string {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	gin.SetMode(gin.ReleaseMode)
+	ng := gin.New()
+
+	ng.Use(gin.Recovery())
+
+	continuousProfilingGroup := ng.Group("/continuous_profiling")
+	HTTPService(continuousProfilingGroup)
+	httpServer := &http.Server{Handler: ng}
+
+	go func() {
+		if err = httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	return listener.Addr().String()
+}

--- a/component/conprof/http/api_test.go
+++ b/component/conprof/http/api_test.go
@@ -1,6 +1,19 @@
 package http
 
 import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/genjidb/genji"
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/ng_monitoring/component/conprof"
@@ -8,11 +21,6 @@ import (
 	"github.com/pingcap/ng_monitoring/config"
 	"github.com/pingcap/ng_monitoring/utils/testutil"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"net"
-	"net/http"
-	"os"
-	"testing"
 )
 
 type testSuite struct {
@@ -59,21 +67,187 @@ func TestAPI(t *testing.T) {
 		{Name: topology.ComponentPD, IP: addr, Port: port, StatusPort: port},
 		{Name: topology.ComponentTiDB, IP: addr, Port: port, StatusPort: port},
 		{Name: topology.ComponentTiKV, IP: addr, Port: port, StatusPort: port},
-		{Name: topology.ComponentTiFlash, IP: addr, Port: port, StatusPort: port},
 	}
+	topology.InitForTest(components)
 	// notify topology
 	topoSubScribe <- components
 
-	// wait for scrape finish
-	//time.Sleep(time.Millisecond * 1500)
+	testErrorRequest(t, httpAddr)
 
-	// test for group_profiles api
-	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/group_profiles")
+	// wait for scrape finish
+	time.Sleep(time.Millisecond * 1500)
+
+	validTs := testAPIGroupProfiles(t, httpAddr)
+	testAPIGroupProfileDetail(t, httpAddr, validTs, components)
+	testAPISingleProfileView(t, httpAddr, validTs, components)
+	testAPIDownload(t, httpAddr, validTs, components)
+	testAPIComponent(t, httpAddr, components)
+	testAPIEstimateSize(t, httpAddr, components)
+}
+
+func testAPIGroupProfiles(t *testing.T, httpAddr string) int64 {
+	ts := time.Now().Unix()
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/group_profiles?begin_time=0&end_time=" + strconv.Itoa(int(ts)))
 	require.NoError(t, err)
-	require.Equal(t, 503, resp.StatusCode)
+	require.Equal(t, 200, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, `{"message":"need param begin_time","status":"error"}`, string(body))
+
+	var groupProfiles []GroupProfiles
+	err = json.Unmarshal(body, &groupProfiles)
+	require.NoError(t, err)
+	require.True(t, len(groupProfiles) > 0)
+	for _, gp := range groupProfiles {
+		require.Equal(t, ComponentNum{TiDB: 1, PD: 1, TiKV: 1, TiFlash: 0}, gp.CompNum)
+		require.True(t, gp.Ts > 0)
+	}
+	return groupProfiles[0].Ts
+}
+
+func testAPIGroupProfileDetail(t *testing.T, httpAddr string, ts int64, components []topology.Component) {
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/group_profile/detail?ts=" + strconv.Itoa(int(ts)))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var groupProfileDetail GroupProfileDetail
+	err = json.Unmarshal(body, &groupProfileDetail)
+	require.NoError(t, err)
+	require.True(t, groupProfileDetail.Ts > 0)
+	require.True(t, len(groupProfileDetail.TargetProfiles) >= len(components))
+	for _, tp := range groupProfileDetail.TargetProfiles {
+		require.Equal(t, "", tp.Error)
+		require.Equal(t, "success", tp.State)
+		found := false
+		for _, comp := range components {
+			if tp.Target.Component == comp.Name && tp.Target.Address == fmt.Sprintf("%v:%v", comp.IP, comp.Port) {
+				found = true
+				break
+			}
+		}
+		require.True(t, found)
+	}
+}
+
+func testAPISingleProfileView(t *testing.T, httpAddr string, ts int64, components []topology.Component) {
+	for _, comp := range components {
+		url := fmt.Sprintf("http://%v/continuous_profiling/single_profile/view?ts=%v&profile_type=profile&component=%v&address=%v:%v", httpAddr, ts, comp.Name, comp.IP, comp.Port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "profile", string(body))
+	}
+}
+
+func testAPIDownload(t *testing.T, httpAddr string, ts int64, components []topology.Component) {
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/download?ts=" + strconv.Itoa(int(ts)))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	require.NoError(t, err)
+	require.True(t, len(zr.File) > len(components))
+	for _, f := range zr.File {
+		// file name format is: kind_component_ip_port_ts
+		fields := strings.Split(f.Name, "_")
+		require.True(t, len(fields) >= 4)
+		reader, err := f.Open()
+		require.NoError(t, err)
+
+		// check content
+		buf := make([]byte, len(fields[0]))
+		n, _ := reader.Read(buf)
+		require.Equal(t, len(fields[0]), n)
+		require.Equal(t, fields[0], string(buf))
+
+		found := false
+		for _, comp := range components {
+			if fields[1] == comp.Name && fields[2] == comp.IP {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, f.Name)
+	}
+}
+
+func testAPIComponent(t *testing.T, httpAddr string, components []topology.Component) {
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/components")
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var comps []topology.Component
+	err = json.Unmarshal(body, &comps)
+	require.NoError(t, err)
+	require.Equal(t, len(components), len(comps))
+	for _, tc := range comps {
+		found := false
+		for _, comp := range components {
+			if tc == comp {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, tc)
+	}
+}
+
+func testAPIEstimateSize(t *testing.T, httpAddr string, components []topology.Component) {
+	resp, err := http.Get("http://" + httpAddr + "/continuous_profiling/estimate_size")
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var estimateSize EstimateSize
+	err = json.Unmarshal(body, &estimateSize)
+	require.NoError(t, err)
+	require.Equal(t, len(components), estimateSize.InstanceCount, string(body))
+	require.Equal(t, 88915968000, estimateSize.ProfileSize)
+}
+
+func testErrorRequest(t *testing.T, httpAddr string) {
+	cases := []struct {
+		api  string
+		body string
+	}{
+		// test for group_profiles api
+		{"/group_profiles", `{"message":"need param begin_time","status":"error"}`},
+		{"/group_profiles?begin_time=0", `{"message":"need param end_time","status":"error"}`},
+		{"/group_profiles?begin_time=0&end_time=zx", `{"message":"invalid param end_time value, error: strconv.ParseInt: parsing \"zx\": invalid syntax","status":"error"}`},
+
+		// test for /group_profile/detail api.
+		{"/group_profile/detail", `{"message":"need param ts","status":"error"}`},
+		{"/group_profile/detail?ts=x", `{"message":"invalid param ts value, error: strconv.ParseInt: parsing \"x\": invalid syntax","status":"error"}`},
+		{"/group_profile/detail?ts=0&limit=x", `{"message":"invalid param limit value, error: strconv.ParseInt: parsing \"x\": invalid syntax","status":"error"}`},
+
+		// test for /single_profile/view api.
+		{"/single_profile/view", `{"message":"need param ts","status":"error"}`},
+		{"/single_profile/view?ts=x", `{"message":"invalid param ts value, error: strconv.ParseInt: parsing \"x\": invalid syntax","status":"error"}`},
+		{"/single_profile/view?ts=0", `{"message":"need param profile_type","status":"error"}`},
+		{"/single_profile/view?ts=0&profile_type=heap", `{"message":"need param component","status":"error"}`},
+		{"/single_profile/view?ts=0&profile_type=heap&component=tidb", `{"message":"need param address","status":"error"}`},
+
+		// test for /download api.
+		{"/download", `{"message":"need param ts","status":"error"}`},
+		{"/download?ts=x", `{"message":"invalid param ts value, error: strconv.ParseInt: parsing \"x\": invalid syntax","status":"error"}`},
+	}
+
+	for _, ca := range cases {
+		resp, err := http.Get("http://" + httpAddr + "/continuous_profiling" + ca.api)
+		require.NoError(t, err)
+		require.Equal(t, 503, resp.StatusCode, ca.api)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, ca.body, string(body), ca.api)
+	}
 }
 
 func setupHTTPService(t *testing.T) string {

--- a/component/conprof/meta/meta_test.go
+++ b/component/conprof/meta/meta_test.go
@@ -1,0 +1,38 @@
+package meta
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaJson(t *testing.T) {
+	target := ProfileTarget{
+		Kind:      "profile",
+		Component: "tidb",
+		Address:   "10.0.1.21:10080",
+	}
+	data, err := json.Marshal(target)
+	require.NoError(t, err)
+	require.Equal(t, `{"kind":"profile","component":"tidb","address":"10.0.1.21:10080"}`, string(data))
+
+	param := BasicQueryParam{
+		Begin:      1,
+		End:        2,
+		Limit:      100,
+		Targets:    []ProfileTarget{target},
+		DataFormat: ProfileDataFormatProtobuf,
+	}
+	data, err = json.Marshal(param)
+	require.NoError(t, err)
+	require.Equal(t, `{"begin_time":1,"end_time":2,"limit":100,"targets":[{"kind":"profile","component":"tidb","address":"10.0.1.21:10080"}],"data_format":"protobuf"}`, string(data))
+
+	list := ProfileList{
+		Target: target,
+		TsList: []int64{1, 2, 3, 4},
+	}
+	data, err = json.Marshal(list)
+	require.NoError(t, err)
+	require.Equal(t, `{"target":{"kind":"profile","component":"tidb","address":"10.0.1.21:10080"},"timestamp_list":[1,2,3,4]}`, string(data))
+}

--- a/component/conprof/scrape/manager.go
+++ b/component/conprof/scrape/manager.go
@@ -19,6 +19,10 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	updateTargetMetaInterval = time.Minute
+)
+
 // Manager maintains a set of scrape pools and manages start/stop cycles
 // when receiving new target groups form the discovery manager.
 type Manager struct {
@@ -80,7 +84,7 @@ func (m *Manager) GetCurrentScrapeComponents() []topology.Component {
 }
 
 func (m *Manager) updateTargetMetaLoop(ctx context.Context) {
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(updateTargetMetaInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -281,6 +285,9 @@ func (m *Manager) GetAllCurrentScrapeSuite() ([]meta.ProfileTarget, []*ScrapeSui
 func (m *Manager) Close() {
 	if m.cancel != nil {
 		m.cancel()
+	}
+	if m.ticker != nil {
+		m.ticker.Stop()
 	}
 	m.store.Close()
 	m.wg.Wait()

--- a/component/conprof/scrape/manager_test.go
+++ b/component/conprof/scrape/manager_test.go
@@ -1,0 +1,246 @@
+package scrape
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/ng_monitoring/component/conprof/meta"
+	"github.com/pingcap/ng_monitoring/component/conprof/store"
+	"github.com/pingcap/ng_monitoring/component/conprof/util"
+	"github.com/pingcap/ng_monitoring/component/topology"
+	"github.com/pingcap/ng_monitoring/config"
+	"github.com/pingcap/ng_monitoring/utils/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+)
+
+func TestMain(m *testing.M) {
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
+	}
+
+	goleak.VerifyTestMain(m, opts...)
+}
+
+func TestManager(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		require.NoError(t, err)
+	}()
+
+	cfg := config.GetDefaultConfig()
+	cfg.ContinueProfiling.Enable = true
+	cfg.ContinueProfiling.ProfileSeconds = 1
+	cfg.ContinueProfiling.IntervalSeconds = 1
+	config.StoreGlobalConfig(&cfg)
+
+	db := testutil.NewGenjiDB(t, tmpDir)
+	defer db.Close()
+	storage, err := store.NewProfileStorage(db)
+	require.NoError(t, err)
+
+	topoSubScribe := make(topology.Subscriber)
+	updateTargetMetaInterval = time.Millisecond * 100
+	manager := NewManager(storage, topoSubScribe)
+	manager.Start()
+	defer manager.Close()
+
+	mockServer := createMockProfileServer(t)
+	defer mockServer.stop(t)
+
+	addr := mockServer.addr
+	port := mockServer.port
+	components := []topology.Component{
+		{Name: topology.ComponentPD, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiDB, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiKV, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiFlash, IP: addr, Port: port, StatusPort: port},
+	}
+	// notify topology
+	topoSubScribe <- components
+
+	t1 := time.Now()
+	// wait for scrape finish
+	time.Sleep(time.Millisecond * 1500)
+
+	t2 := time.Now()
+	param := &meta.BasicQueryParam{
+		Begin:   util.GetTimeStamp(t1),
+		End:     util.GetTimeStamp(t2),
+		Limit:   1000,
+		Targets: nil,
+	}
+	plists, err := storage.QueryGroupProfiles(param)
+	require.NoError(t, err)
+	checkListData := func(plists []meta.ProfileList, components []topology.Component, param *meta.BasicQueryParam) {
+		require.True(t, len(plists) > len(components))
+		maxTs := int64(0)
+		for _, list := range plists {
+			found := false
+			for _, comp := range components {
+				if list.Target.Component == comp.Name && list.Target.Address == fmt.Sprintf("%v:%v", comp.IP, comp.Port) {
+					found = true
+					break
+				}
+			}
+			// TODO(crazycs): remove this after support tiflash
+			require.True(t, list.Target.Component != topology.ComponentTiFlash)
+			require.True(t, found, fmt.Sprintf("%#v", list))
+			for _, ts := range list.TsList {
+				require.True(t, ts >= param.Begin && ts <= param.End)
+				if ts > maxTs {
+					maxTs = ts
+				}
+			}
+		}
+		require.True(t, maxTs > 0)
+	}
+	checkListData(plists, components, param)
+
+	// test for scrape profile data
+	count := 0
+	err = storage.QueryProfileData(param, func(target meta.ProfileTarget, i int64, data []byte) error {
+		count++
+		found := false
+		for _, comp := range components {
+			if target.Component == comp.Name && target.Address == fmt.Sprintf("%v:%v", comp.IP, comp.Port) {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, fmt.Sprintf("%#v", target))
+		require.Equal(t, target.Kind, string(data))
+		return nil
+	})
+	require.True(t, count > len(components))
+	require.NoError(t, err)
+
+	// test for update target meta.
+	for _, list := range plists {
+		info := storage.GetTargetInfoFromCache(list.Target)
+		require.NotNil(t, info)
+		require.True(t, info.ID > 0)
+		require.True(t, info.LastScrapeTs >= util.GetTimeStamp(t1))
+	}
+
+	// test for GetCurrentScrapeComponents
+	comp := manager.GetCurrentScrapeComponents()
+	// // TODO(crazycs): update this after support tiflash
+	require.Equal(t, len(comp), len(components)-1)
+
+	// test for topology changed.
+	mockServer2 := createMockProfileServer(t)
+	defer mockServer2.stop(t)
+	addr2 := mockServer2.addr
+	port2 := mockServer2.port
+	log.Info("new mock server", zap.Uint("port", port2))
+	components = []topology.Component{
+		{Name: topology.ComponentPD, IP: addr2, Port: port2, StatusPort: port2},
+		{Name: topology.ComponentTiDB, IP: addr, Port: port, StatusPort: port},
+		{Name: topology.ComponentTiDB, IP: addr2, Port: port2, StatusPort: port2},
+		{Name: topology.ComponentTiKV, IP: addr2, Port: port2, StatusPort: port2},
+	}
+
+	// mock for disable conprof
+	cfg.ContinueProfiling.Enable = false
+	config.StoreGlobalConfig(&cfg)
+
+	// notify topology
+	topoSubScribe <- components
+
+	// wait for stop scrape
+	time.Sleep(time.Millisecond * 100)
+
+	// currently, shouldn't have any scrape component.
+	comp = manager.GetCurrentScrapeComponents()
+	require.Equal(t, len(comp), 0)
+
+	cfg.ContinueProfiling.Enable = true
+	config.StoreGlobalConfig(&cfg)
+	// renotify topology
+	topoSubScribe <- components
+	// wait for scrape finish
+	time.Sleep(time.Millisecond * 3000)
+
+	t3 := time.Now()
+	param = &meta.BasicQueryParam{
+		Begin:   util.GetTimeStamp(t3) - 1,
+		End:     util.GetTimeStamp(t3),
+		Limit:   1000,
+		Targets: nil,
+	}
+	plists, err = storage.QueryGroupProfiles(param)
+	require.NoError(t, err)
+	checkListData(plists, components, param)
+
+	comp = manager.GetCurrentScrapeComponents()
+	require.Equal(t, len(comp), len(components), fmt.Sprintf("%#v \n %#v", comp, components))
+}
+
+type mockProfileServer struct {
+	addr       string
+	port       uint
+	httpServer *http.Server
+}
+
+func createMockProfileServer(t *testing.T) *mockProfileServer {
+	s := &mockProfileServer{}
+	s.start(t)
+	return s
+}
+
+func (s *mockProfileServer) start(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	router := http.NewServeMux()
+	router.HandleFunc("/debug/pprof/profile", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("profile"))
+	})
+
+	router.HandleFunc("/debug/pprof/mutex", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("mutex"))
+	})
+
+	router.HandleFunc("/debug/pprof/goroutine", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("goroutine"))
+	})
+
+	router.HandleFunc("/debug/pprof/heap", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("heap"))
+	})
+
+	httpServer := &http.Server{
+		Handler: router,
+	}
+	go func() {
+		if err = httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	var port string
+	s.addr, port, err = net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 64)
+	require.NoError(t, err)
+	s.port = uint(p)
+	s.httpServer = httpServer
+}
+
+func (s *mockProfileServer) stop(t *testing.T) {
+	err := s.httpServer.Close()
+	require.NoError(t, err)
+}

--- a/component/conprof/scrape/ticker_test.go
+++ b/component/conprof/scrape/ticker_test.go
@@ -5,12 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
-
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
-}
 
 func TestTicker(t *testing.T) {
 	ticker := NewTicker(time.Millisecond * 50)

--- a/component/conprof/store/gc.go
+++ b/component/conprof/store/gc.go
@@ -22,6 +22,8 @@ func (s *ProfileStorage) doGCLoop() {
 	defer ticker.Stop()
 	for {
 		select {
+		case <-s.ctx.Done():
+			return
 		case <-ticker.C:
 			s.runGC()
 		}

--- a/component/conprof/store/store_test.go
+++ b/component/conprof/store/store_test.go
@@ -103,7 +103,7 @@ func testProfileStorage(t *testing.T, tmpDir string, baseTs int64, cleanCache bo
 		_, err = storage.UpdateProfileTargetInfo(pt, ts)
 		require.NoError(t, err)
 
-		info := storage.getTargetInfoFromCache(pt)
+		info := storage.GetTargetInfoFromCache(pt)
 		require.NotNil(t, info)
 		require.Equal(t, info.LastScrapeTs, ts)
 	}

--- a/component/conprof/store/store_test.go
+++ b/component/conprof/store/store_test.go
@@ -1,0 +1,182 @@
+package store
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/genjidb/genji"
+	"github.com/genjidb/genji/engine/badgerengine"
+	"github.com/pingcap/ng_monitoring/component/conprof/meta"
+	"github.com/pingcap/ng_monitoring/component/conprof/util"
+	"github.com/pingcap/ng_monitoring/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileStorage(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		require.NoError(t, err)
+	}()
+	baseTs := util.GetTimeStamp(time.Now())
+	for i := 0; i < 2; i++ {
+		testProfileStorage(t, tmpDir, baseTs+int64(i*1000), i > 0)
+	}
+
+	testProfileStorageGC(t, tmpDir, baseTs)
+}
+
+func testProfileStorageGC(t *testing.T, tmpDir string, baseTs int64) {
+	genjiDB := newGenjiDB(t, tmpDir)
+	defer genjiDB.Close()
+	storage, err := NewProfileStorage(genjiDB)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	originSize := len(storage.metaCache)
+	require.True(t, originSize > 0)
+
+	cfg := config.GetDefaultConfig()
+	cfg.ContinueProfiling.DataRetentionSeconds = -100000
+	config.StoreGlobalConfig(&cfg)
+	storage.runGC()
+	require.Equal(t, 0, len(storage.metaCache))
+}
+
+func testProfileStorage(t *testing.T, tmpDir string, baseTs int64, cleanCache bool) {
+	genjiDB := newGenjiDB(t, tmpDir)
+	defer genjiDB.Close()
+	storage, err := NewProfileStorage(genjiDB)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	if cleanCache {
+		storage.metaCache = make(map[meta.ProfileTarget]*meta.TargetInfo)
+	}
+
+	cases := []struct {
+		kind      string
+		component string
+		address   string
+		data      []byte
+	}{
+		{"profile", "tidb", "127.0.0.1:10080", mockProfile()},
+		{"profile", "pd", "127.0.0.1:2379", mockProfile()},
+		{"profile", "tikv", "127.0.0.1:20180", mockProfile()},
+		{"goroutine", "tidb", "127.0.0.1:10080", mockProfile()},
+		{"heap", "tidb", "127.0.0.1:10080", mockProfile()},
+	}
+
+	for i, ca := range cases {
+		pt := meta.ProfileTarget{Kind: ca.kind, Component: ca.component, Address: ca.address}
+		ts := baseTs + int64(i)
+		err = storage.AddProfile(pt, ts, ca.data)
+		require.NoError(t, err)
+
+		param := &meta.BasicQueryParam{
+			Begin:   ts,
+			End:     ts,
+			Limit:   100,
+			Targets: []meta.ProfileTarget{pt},
+		}
+		list, err := storage.QueryGroupProfiles(param)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(list))
+		require.Equal(t, pt, list[0].Target)
+		require.Equal(t, 1, len(list[0].TsList))
+		require.Equal(t, ts, list[0].TsList[0])
+
+		executed := false
+		err = storage.QueryProfileData(param, func(target meta.ProfileTarget, timestamp int64, data []byte) error {
+			require.Equal(t, pt, target)
+			require.Equal(t, ts, timestamp)
+			require.Equal(t, ca.data, data)
+			executed = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, executed)
+
+		_, err = storage.UpdateProfileTargetInfo(pt, ts)
+		require.NoError(t, err)
+
+		info := storage.getTargetInfoFromCache(pt)
+		require.NotNil(t, info)
+		require.Equal(t, info.LastScrapeTs, ts)
+	}
+	param := &meta.BasicQueryParam{
+		Begin: baseTs,
+		End:   baseTs + int64(len(cases)),
+		Limit: 100,
+	}
+	lists, err := storage.QueryGroupProfiles(param)
+	require.NoError(t, err)
+	require.Equal(t, len(cases), len(lists))
+	for _, list := range lists {
+		found := false
+		for idx, ca := range cases {
+			pt := meta.ProfileTarget{Kind: ca.kind, Component: ca.component, Address: ca.address}
+			if pt == list.Target {
+				require.Equal(t, 1, len(list.TsList))
+				require.Equal(t, baseTs+int64(idx), list.TsList[0])
+				found = true
+			}
+		}
+		require.Equal(t, true, found)
+	}
+
+	err = storage.QueryProfileData(param, func(target meta.ProfileTarget, timestamp int64, data []byte) error {
+		found := false
+		for idx, ca := range cases {
+			pt := meta.ProfileTarget{Kind: ca.kind, Component: ca.component, Address: ca.address}
+			if pt == target {
+				require.Equal(t, baseTs+int64(idx), timestamp)
+				require.Equal(t, ca.data, data)
+				found = true
+			}
+		}
+		require.Equal(t, true, found)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func mockProfile() []byte {
+	size := 50*1024 + rand.Intn(50*1024)
+	data := make([]byte, size)
+	for i := 0; i < size; i += 99 {
+		data[i] = byte(i % 255)
+	}
+	return data
+}
+
+func verifyMockProfile(data []byte) bool {
+	if len(data) < 50*1024 {
+		return false
+	}
+	for i := 0; i < len(data); i += 99 {
+		if data[i] != byte(i%255) {
+			return false
+		}
+	}
+	return true
+}
+
+func newGenjiDB(t *testing.T, storagePath string) *genji.DB {
+	opts := badger.DefaultOptions(storagePath).
+		WithZSTDCompressionLevel(3).
+		WithBlockSize(8 * 1024).
+		WithValueThreshold(128 * 1024)
+
+	engine, err := badgerengine.NewEngine(opts)
+	require.NoError(t, err)
+	db, err := genji.New(context.Background(), engine)
+	require.NoError(t, err)
+	return db
+}

--- a/component/topology/discovery.go
+++ b/component/topology/discovery.go
@@ -13,11 +13,14 @@ import (
 )
 
 const (
-	discoverInterval = time.Second * 30
 	ComponentTiDB    = "tidb"
 	ComponentTiKV    = "tikv"
 	ComponentTiFlash = "tiflash"
 	ComponentPD      = "pd"
+)
+
+var (
+	discoverInterval = time.Second * 30
 )
 
 type TopologyDiscoverer struct {

--- a/component/topology/syncer.go
+++ b/component/topology/syncer.go
@@ -21,7 +21,10 @@ const (
 	newSessionRetryInterval = 200 * time.Millisecond
 	logIntervalCnt          = int(3 * time.Second / newSessionRetryInterval)
 	topologySessionTTL      = 45
-	topologyTimeToRefresh   = 30 * time.Second
+)
+
+var (
+	topologyTimeToRefresh = 30 * time.Second
 )
 
 type TopologySyncer struct {

--- a/component/topology/topology.go
+++ b/component/topology/topology.go
@@ -22,6 +22,10 @@ func Init() error {
 	return err
 }
 
+func InitForTest(comps []Component) {
+	discover = &TopologyDiscoverer{components: comps}
+}
+
 func GetCurrentComponent() []Component {
 	if discover == nil {
 		return nil

--- a/component/topology/topology_test.go
+++ b/component/topology/topology_test.go
@@ -1,0 +1,172 @@
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/pingcap/ng_monitoring/config"
+	"github.com/pingcap/tidb-dashboard/util/client/pdclient"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
+)
+
+func TestTopology(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration.NewClusterV3 will create file contains a colon which is not allowed on Windows")
+	}
+	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer cluster.Terminate(t)
+	mockPD := mockPDHTTPServer{}
+	mockPD.setup(t)
+	defer mockPD.down(t)
+
+	cfg := config.GetDefaultConfig()
+	cfg.AdvertiseAddress = "10.0.1.8:12020"
+	cli, err := NewClientForTest(&cfg, cluster.RandClient())
+	require.NotNil(t, err)
+	require.Equal(t, "need specify pd endpoints", err.Error())
+	cfg.PD.Endpoints = []string{mockPD.addr}
+	config.StoreGlobalConfig(&cfg)
+	mockPD.health = false
+	cli, err = NewClientForTest(&cfg, cluster.RandClient())
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Response status 503")
+	mockPD.health = true
+	cli, err = NewClientForTest(&cfg, cluster.RandClient())
+	require.NoError(t, err)
+
+	discover = &TopologyDiscoverer{
+		cli:         cli,
+		cfgChangeCh: make(chan struct{}, 1),
+		notifyCh:    make(chan struct{}, 1),
+		closed:      make(chan struct{}),
+	}
+	err = discover.loadTopology()
+	require.NoError(t, err)
+
+	sub := discover.Subscribe()
+	discoverInterval = time.Millisecond * 100
+	go discover.loadTopologyLoop()
+
+	// test for config change channel
+	discover.cfgChangeCh <- struct{}{}
+
+	components := <-sub
+	require.Equal(t, len(components), 2)
+	require.Equal(t, components[0].Name, "pd")
+	require.Equal(t, components[1].Name, "tikv")
+
+	// test syncer
+	syncer = NewTopologySyncer()
+	err = syncer.newTopologySessionAndStoreServerInfo()
+	require.NoError(t, err)
+	err = syncer.storeTopologyInfo()
+	require.NoError(t, err)
+
+	// get ngm topology from etcd.
+	etcdCli := cluster.RandClient()
+	resp, err := etcdCli.Get(context.Background(), topologyPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	require.Equal(t, 1, int(resp.Count))
+	require.Equal(t, "/topology/ng-monitoring/10.0.1.8:12020/ttl", string(resp.Kvs[0].Key))
+
+	// test syncer sync.
+	topologyTimeToRefresh = time.Millisecond * 10
+	syncer.Start()
+	respd, err := etcdCli.Delete(context.Background(), topologyPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	require.Equal(t, 1, int(respd.Deleted))
+	// wait syncer to restore the info.
+	time.Sleep(time.Millisecond * 100)
+	resp, err = etcdCli.Get(context.Background(), topologyPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	require.Equal(t, 1, int(resp.Count))
+	require.Equal(t, "/topology/ng-monitoring/10.0.1.8:12020/ttl", string(resp.Kvs[0].Key))
+	Stop()
+}
+
+type mockPDHTTPServer struct {
+	addr       string
+	httpServer *http.Server
+	health     bool
+}
+
+func (s *mockPDHTTPServer) setup(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	router := http.NewServeMux()
+	router.HandleFunc("/pd/api/v1/health", func(writer http.ResponseWriter, request *http.Request) {
+		if !s.health {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		resp := pdclient.GetHealthResponse{
+			{MemberID: 1, Health: s.health},
+		}
+		s.writeJson(t, writer, resp)
+	})
+
+	router.HandleFunc("/pd/api/v1/status", func(writer http.ResponseWriter, request *http.Request) {
+		resp := pdclient.GetStatusResponse{
+			StartTimestamp: time.Now().Unix(),
+		}
+		s.writeJson(t, writer, resp)
+	})
+
+	router.HandleFunc("/pd/api/v1/members", func(writer http.ResponseWriter, request *http.Request) {
+		resp := pdclient.GetMembersResponse{
+			Members: []struct {
+				GitHash       string   `json:"git_hash"`
+				ClientUrls    []string `json:"client_urls"`
+				DeployPath    string   `json:"deploy_path"`
+				BinaryVersion string   `json:"binary_version"`
+				MemberID      uint64   `json:"member_id"`
+			}{
+				{GitHash: "abcd", ClientUrls: []string{"http://" + s.addr}, DeployPath: "data", BinaryVersion: "v5.3.0", MemberID: 1},
+			},
+		}
+		s.writeJson(t, writer, resp)
+	})
+
+	router.HandleFunc("/pd/api/v1/stores", func(writer http.ResponseWriter, request *http.Request) {
+		resp := pdclient.GetStoresResponse{
+			Stores: []struct {
+				Store pdclient.GetStoresResponseStore
+			}{
+				{pdclient.GetStoresResponseStore{Address: "127.0.0.1:20160", ID: 1, Version: "v5.3.0", StatusAddress: "127.0.0.1:20180", StartTimestamp: time.Now().Unix(), StateName: "up"}},
+			},
+		}
+		s.writeJson(t, writer, resp)
+	})
+
+	httpServer := &http.Server{
+		Handler: router,
+	}
+	go func() {
+		if err = httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	s.health = true
+	s.addr = listener.Addr().String()
+	s.httpServer = httpServer
+}
+
+func (s *mockPDHTTPServer) writeJson(t *testing.T, writer http.ResponseWriter, resp interface{}) {
+	writer.WriteHeader(http.StatusOK)
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+}
+
+func (s *mockPDHTTPServer) down(t *testing.T) {
+	err := s.httpServer.Close()
+	require.NoError(t, err)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -222,6 +222,10 @@ func (l *Log) InitDefaultLogger() {
 }
 
 func ReloadRoutine(ctx context.Context, configPath string, currentCfg *Config) {
+	if len(configPath) == 0 {
+		log.Warn("failed to reload config due to empty config path. Please specify the command line argument \"--config <path>\"")
+		return
+	}
 	sighupCh := procutil.NewSighupChan()
 	for {
 		select {
@@ -231,11 +235,6 @@ func ReloadRoutine(ctx context.Context, configPath string, currentCfg *Config) {
 			log.Info("received SIGHUP and ready to reload config")
 		}
 		newCfg := new(Config)
-
-		if len(configPath) == 0 {
-			log.Warn("failed to reload config due to empty config path. Please specify the command line argument \"--config <path>\"")
-			continue
-		}
 
 		if err := newCfg.Load(configPath); err != nil {
 			log.Warn("failed to reload config", zap.Error(err))

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,10 @@ func GetGlobalConfig() *Config {
 	return globalConf.Load().(*Config)
 }
 
+func GetDefaultConfig() Config {
+	return defaultConfig
+}
+
 // StoreGlobalConfig stores a new config to the globalConf. It mostly uses in the test to avoid some data races.
 func StoreGlobalConfig(config *Config) {
 	globalConf.Store(config)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,15 +1,23 @@
 package config
 
 import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/procutil"
+	"github.com/genjidb/genji"
+	"github.com/pingcap/ng_monitoring/utils/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
-	config := defaultConfig
+	config := GetDefaultConfig()
 	config.PD.Endpoints = append(config.PD.Endpoints, "10.0.1.8:2379")
 	require.NoError(t, config.valid())
 	require.Equal(t, config.PD, PD{Endpoints: []string{"10.0.1.8:2379"}})
@@ -46,4 +54,231 @@ func TestContinueProfilingConfig(t *testing.T) {
 		DataRetentionSeconds: 10000,
 	}
 	require.Equal(t, cfg.Valid(), true)
+}
+
+func TestConfigInit(t *testing.T) {
+	cfgFileName := "test-cfg.toml"
+	cfgData := `
+address = "0.0.0.0:12020"
+advertise-address = "10.0.1.8:12020"
+[log]
+path = "log"
+level = "INFO"
+[pd]
+endpoints = ["10.0.1.8:2379"]
+[storage]
+path = "data"
+[security]
+ca-path = "ngm.ca"
+cert-path = "ngm.cert"
+key-path = "ngm.key"`
+	err := ioutil.WriteFile(cfgFileName, []byte(cfgData), 0666)
+	require.NoError(t, err)
+	defer os.Remove(cfgFileName)
+
+	cfg, err := InitConfig(cfgFileName, func(config *Config) {})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.Equal(t, `{"address":"0.0.0.0:12020","advertise_address":"10.0.1.8:12020","pd":{"endpoints":["10.0.1.8:2379"]},"log":{"path":"log","level":"INFO"},"storage":{"path":"data"},"continuous_profiling":{"enable":false,"profile_seconds":10,"interval_seconds":60,"timeout_seconds":120,"data_retention_seconds":259200},"security":{"ca_path":"ngm.ca","cert_path":"ngm.cert","key_path":"ngm.key"}}`, string(data))
+
+	go ReloadRoutine(context.Background(), cfgFileName, cfg)
+	time.Sleep(time.Millisecond * 10)
+	cfgData = `
+address = "0.0.0.1:12020"
+advertise-address = "10.0.1.9:12020"
+[log]
+path = "log1"
+level = "ERROR"
+[pd]
+endpoints = ["10.0.1.8:2378", "10.0.1.9:2379"]
+[storage]
+path = "data1"`
+	cfgSub := SubscribeConfigChange()
+	err = ioutil.WriteFile(cfgFileName, []byte(cfgData), 0666)
+	require.NoError(t, err)
+
+	procutil.SelfSIGHUP()
+	<-cfgSub
+	data, err = json.Marshal(GetGlobalConfig())
+	require.NoError(t, err)
+	require.Equal(t, `{"address":"0.0.0.0:12020","advertise_address":"10.0.1.8:12020","pd":{"endpoints":["10.0.1.8:2378","10.0.1.9:2379"]},"log":{"path":"log","level":"INFO"},"storage":{"path":"data"},"continuous_profiling":{"enable":false,"profile_seconds":10,"interval_seconds":60,"timeout_seconds":120,"data_retention_seconds":259200},"security":{"ca_path":"ngm.ca","cert_path":"ngm.cert","key_path":"ngm.key"}}`, string(data))
+
+	cfgData = ``
+	err = ioutil.WriteFile(cfgFileName, []byte(cfgData), 0666)
+	require.NoError(t, err)
+	procutil.SelfSIGHUP()
+	// wait reload
+	time.Sleep(time.Millisecond * 10)
+	data, err = json.Marshal(GetGlobalConfig())
+	require.NoError(t, err)
+	require.Equal(t, `{"address":"0.0.0.0:12020","advertise_address":"10.0.1.8:12020","pd":{"endpoints":["10.0.1.8:2378","10.0.1.9:2379"]},"log":{"path":"log","level":"INFO"},"storage":{"path":"data"},"continuous_profiling":{"enable":false,"profile_seconds":10,"interval_seconds":60,"timeout_seconds":120,"data_retention_seconds":259200},"security":{"ca_path":"ngm.ca","cert_path":"ngm.cert","key_path":"ngm.key"}}`, string(data))
+}
+
+func TestConfigValid(t *testing.T) {
+	// Test PD valid
+	pdCfg := PD{Endpoints: []string{}}
+	require.Error(t, pdCfg.valid())
+	require.Equal(t, pdCfg.valid().Error(), "unexpected empty pd endpoints, please specify at least one, e.g. --pd.endpoints \"[127.0.0.1:2379]\"")
+	// Test Log
+	logCfg := Log{}
+	require.Equal(t, logCfg.valid().Error(), "unexpected empty log path")
+	logCfg = Log{Path: "log"}
+	require.Equal(t, logCfg.valid().Error(), "unexpected empty log level")
+	logCfg = Log{Path: "log", Level: "unknow"}
+	require.Equal(t, logCfg.valid().Error(), "log level should be DEBUG, INFO, WARN or ERROR")
+	logCfg = Log{Path: "log", Level: "INFO"}
+	require.Equal(t, logCfg.valid(), nil)
+	logCfg.InitDefaultLogger()
+	// Test Storage
+	storageCfg := Storage{}
+	require.Equal(t, storageCfg.valid().Error(), "unexpected empty storage path")
+	storageCfg = Storage{Path: "data"}
+	require.Equal(t, storageCfg.valid(), nil)
+	config := Config{}
+	require.Equal(t, config.valid().Error(), "unexpected empty address")
+	config = Config{PD: pdCfg, Log: logCfg, Storage: storageCfg}
+	require.Equal(t, logCfg.valid(), nil)
+}
+
+func TestPDConfigEqual(t *testing.T) {
+	// Test PD Equal
+	pd1 := PD{Endpoints: []string{"10.0.1.8:2379", "10.0.1.9:2379"}}
+	pd2 := PD{Endpoints: []string{"10.0.1.8:2378", "10.0.1.9:2378"}}
+	require.False(t, pd1.Equal(pd2))
+	pd2 = PD{Endpoints: []string{"10.0.1.8:2379"}}
+	require.False(t, pd1.Equal(pd2))
+	pd2 = PD{Endpoints: []string{"10.0.1.8:2379", "10.0.1.9:2379"}}
+	require.True(t, pd1.Equal(pd2))
+}
+
+func TestTLS(t *testing.T) {
+	cfg := Config{Security: Security{}}
+	require.Equal(t, "http", cfg.GetHTTPScheme())
+	caFile := "ca.crt"
+	certFile := "ng.crt"
+	pemFile := "ng.pem"
+	err := ioutil.WriteFile(caFile, []byte(`-----BEGIN CERTIFICATE-----
+MIIDMDCCAhigAwIBAgIRAMe2loaMmf+umFBmQ9OKWBswDQYJKoZIhvcNAQELBQAw
+ITEQMA4GA1UEChMHUGluZ0NBUDENMAsGA1UECxMEVGlVUDAgFw0yMTExMzAwNDQ5
+MjZaGA8yMDcxMTExODA0NDkyNlowITEQMA4GA1UEChMHUGluZ0NBUDENMAsGA1UE
+CxMEVGlVUDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALFAh2grK5ZC
+zDhlp/cMA9Ph2WIZWIqMEVqU5J2l2i1+C+4hEZf7fwYKuA53x47ma2gCTiOM/9Tb
+PsXJQDRdI76sDSW1D0Q5E5FIgPt4MJ2Ge5WNB0oqEp0EYJxcIOFjPB+euizFAJml
+DvBARJBfvlXjfyvLnzzMJq17cZxGI+ZFlHBIwdz1W6kaBp4ufNc615NZGne8LE0H
+9Xi9+5tQAj6Wd0G18Zm8heROsKZdoSNAEq51JJE8mXBw7hDiKcGxkTTjovU3wOGO
+SIN/PgOOGLzQyP2UwtptzQxpnkschYd0RNwk7PAVtAQLDzqad29Pv4PIKNNW18In
+ZzQiUlSJjl0CAwEAAaNhMF8wDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsG
+AQUFBwMCBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQI1oUI
+BkHltHykqaYYfu40x9QSWjANBgkqhkiG9w0BAQsFAAOCAQEATmMz6A/aCRdPSenF
+ejObbH8m2L0jdxFf6xNXrKRI63CGD0xurniUSxAEYU7Ee6githkb9BsUSbmJWtwj
+K3H6uNgsDj8BGiNAsI7YZo2cmo/z+mtP1tmevaP0GjnM3D6r6G/9XR8a7lkze91q
+EaEOHyXhZh3gZlVeaiiDuWNpsDV45l2MtgosCyjmnClPlo5tFtEaVekI/uVW/eBJ
+UqSQx401a2pJ4KP6DOW+2TEYjrqKVUBYNTgU7WjIac26YCnJcNDyNa8pEd4i6WVv
+iyiUYFjTLgtegJgkOpDCKDyfj5l3OURQ2kemS1uv030uES6VaSvTfEuxtP27H1Aw
+OFk8KA==
+-----END CERTIFICATE-----`), 0666)
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(certFile, []byte(`-----BEGIN CERTIFICATE-----
+MIIDaTCCAlGgAwIBAgIRANt69n9jMGq75NskvBIbG98wDQYJKoZIhvcNAQELBQAw
+ITEQMA4GA1UEChMHUGluZ0NBUDENMAsGA1UECxMEVGlVUDAeFw0yMTExMzAwNDUw
+MjhaFw0zMTExMjgwNDUwMjhaMEkxEDAOBgNVBAoTB1BpbmdDQVAxIDALBgNVBAsT
+BFRpVVAwEQYDVQQLEwpwcm9tZXRoZXVzMRMwEQYDVQQDEwpwcm9tZXRoZXVzMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0St0F7BIM9FFBXYyx2b/5yXG
+SoaFWEgqcoHXw0Fj6qdmaO4ZOsQIkHQjA8deNHSjzkEvsZd4sTYaHbGe6qCsdu5Z
+rVl1/zlIvN9juwcHAQPZfNKrfrBvE78IXnGc0xb1ibxwwGxjKahDMNTlFF/+Pb26
+Sg5LVJL2EXlXSlF9pgURzW35iu3aU7SrKpaUBk4flnOkeUXbuZb/KmrYbJSL/wuz
+VYa0idtaWAHM0+dIc75qnkYLiKr1TsvXmDZRLlzIegHQ9BxKSCDytk3xnYA5tKjA
+DI2nlzrPGBgrNzJ8sEEB7bXQ0wSygf2pEgKtcQMLP2cuZtnw32KEXlebj2FWHQID
+AQABo3QwcjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsG
+AQUFBwMBMB8GA1UdIwQYMBaAFAjWhQgGQeW0fKSpphh+7jTH1BJaMCAGA1UdEQQZ
+MBeCCWxvY2FsaG9zdIcEfwAAAYcECgABCzANBgkqhkiG9w0BAQsFAAOCAQEAlnQa
+MGavPqk+iNHFn8LRW6cSUyTBtmCC47YJLge/tt2xqQb8jR+f28+zqBeo6NNi2mnb
+tnSDHhj6qrcjjaIA5VL5op5+yWmNkqXR6yBjTqmdxLgWsLVsPFMXS2DtN8qZ0ukl
+SxVNybD8NvWoCGdedNSEpQ+Gd3UxXK2gjPdZHPo3n0h9u8xfqKRNOQmg2N3GYSmp
+fS6knrveE9Mmfgg/FmtcKi4WEd9+gydYzGwBiYRe1wIWjK1xuN3by00XEQR77wlb
+mNGLnQMjURirpbLNCR9+IAsXk99VfCL0dVzZxo/pIz0fPqpwQfxj9ku8+yUJ4KqS
+7195bvDsBG8Jnj/xiA==
+-----END CERTIFICATE-----`), 0666)
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(pemFile, []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0St0F7BIM9FFBXYyx2b/5yXGSoaFWEgqcoHXw0Fj6qdmaO4Z
+OsQIkHQjA8deNHSjzkEvsZd4sTYaHbGe6qCsdu5ZrVl1/zlIvN9juwcHAQPZfNKr
+frBvE78IXnGc0xb1ibxwwGxjKahDMNTlFF/+Pb26Sg5LVJL2EXlXSlF9pgURzW35
+iu3aU7SrKpaUBk4flnOkeUXbuZb/KmrYbJSL/wuzVYa0idtaWAHM0+dIc75qnkYL
+iKr1TsvXmDZRLlzIegHQ9BxKSCDytk3xnYA5tKjADI2nlzrPGBgrNzJ8sEEB7bXQ
+0wSygf2pEgKtcQMLP2cuZtnw32KEXlebj2FWHQIDAQABAoIBAQCMlolMFrcg5Opg
+Vmag8dDUeuZBVxMvGCo3lp//4+aVZHiH1Gjuv64F8ZlLQ+hEl5U130iANA/yBCwf
+gzAOAXqJ4YAy7GtL5SPHltpAbeO+QekfZbXQzCOMgRzN5c0DcG4OarLaEr+/0xF+
+M8nZHQAUXX5loh/ts21ip00NbaJnP89elgv3U5SupeyPLQZ7ke9xFYCTy5ujOf8Y
+fPKpSlpT+vTR6PYeArUEuo9+mQ2JfdFt5h0YeJxiv6G41Msoeo4ucpQDsTf23UAm
+FWEac57Or46+x/HWB3tbS0it9ce3roY0HmFKo7E0TL138fDjHup5ruECXBRZ9gMw
+jlg7AAxBAoGBAPZdtIFhAG/6AuzKyGsqPvymb8wPbwIQfH3Y84xqIxvDiyyjSFBj
+NAKkCS3ink8U9GjG85drd14wO6QOa9im/mFuBYzBvZYn8aWu7P/9Ar35BamsPOKK
+7g91pl1WzAnAaEbg4NjdjCyxuff0e7Q9FdU7ak9vkA+cKZfXSPpSHAIxAoGBANlZ
+Yz5gMyTvGST2QuJL0loLSKznvjk3uB3pdB32RHsyewqDLofpHVB3A7zEbVZR0Lbg
+pBLAvqda72rqU4LQXZFPPugV3LWUAsn3jl92oUmrStt6eFIUuZUMMk49BkjUELK2
+X585vzGqdCmxVYXILD9FKIHPBkkeG058h27rZ8utAoGBAMZq5auloiKNKrnm/88/
+cQcuTK/+Zhs1h+4bQtt9x9TegkJrJxyHKSZPUo1ADNwINmgEg78Z8ENNeVtBuh39
+MLbrU1Dv4G8EsJwN7BangQPbgXILo+WYmu6chGZ8N0xLSDB9gNloZTLB2NMYdmDN
+Kb5YYeCkK1RHI0CFRONGKgShAoGADYZAZKs7w3qVR/WC5+3r4up81TV+YrUS4dma
+/hpK3JehjF/pT0+0IUOmmeJnI03n/NkxnHEd6+/+odp+487vY5FYyrxBhZL2MXcU
+BuCs3JaqC8otHn5npdyibLfjYji/6T7r6E6BlSeUHtwIBFEWX8F/6cPmEjqrXFDn
+ZIGFbekCgYAjwwN0asGruVmTOipxPBccdfwZ8oz4/sBFIKhDf8T7JRc90SWgnidh
+AHLPXeMGpx1QBP47VNlyClZhXMK7Yjkzmx2FIzCnYb4PG+Q+RPRse+UFNQvrPKii
+Kv2FPAw7FhnHGC8nFubb4XtyPhFzNNv/J17pBsZNdGQuFawkyhpbCQ==
+-----END RSA PRIVATE KEY-----`), 0644)
+	require.NoError(t, err)
+	defer func() {
+		os.Remove(caFile)
+		os.Remove(certFile)
+		os.Remove(pemFile)
+	}()
+	cfg.Security = Security{
+		SSLCA:   caFile,
+		SSLCert: certFile,
+		SSLKey:  pemFile,
+	}
+	require.Equal(t, "https", cfg.GetHTTPScheme())
+
+	ccfg := cfg.Security.GetHTTPClientConfig()
+	require.Equal(t, ccfg.TLSConfig.CAFile, caFile)
+	require.Equal(t, ccfg.TLSConfig.CertFile, certFile)
+	require.Equal(t, ccfg.TLSConfig.KeyFile, pemFile)
+}
+
+func TestConfigPersist(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		require.NoError(t, err)
+	}()
+	db := testutil.NewGenjiDB(t, tmpDir)
+	defer db.Close()
+
+	err = LoadConfigFromStorage(func() *genji.DB {
+		return db
+	})
+	require.NoError(t, err)
+
+	oldCfg := GetGlobalConfig()
+	cfg := *oldCfg
+	cfg.ContinueProfiling.Enable = true
+	cfg.ContinueProfiling.IntervalSeconds = 100
+	StoreGlobalConfig(&cfg)
+	err = saveConfigIntoStorage()
+	require.NoError(t, err)
+
+	defCfg := GetDefaultConfig()
+	StoreGlobalConfig(&defCfg)
+	err = LoadConfigFromStorage(func() *genji.DB {
+		return db
+	})
+	curCfg := GetGlobalConfig()
+	require.Equal(t, true, curCfg.ContinueProfiling.Enable)
+	require.Equal(t, 100, curCfg.ContinueProfiling.IntervalSeconds)
 }

--- a/config/pdvariable/pdvariable_test.go
+++ b/config/pdvariable/pdvariable_test.go
@@ -1,0 +1,64 @@
+package pdvariable_test
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/ng_monitoring/config/pdvariable"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
+)
+
+func TestPDVariableSubscribe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration.NewClusterV3 will create file contains a colon which is not allowed on Windows")
+	}
+
+	for i := 0; i < 2; i++ {
+		testPDVariableSubscribe(t, i%2 == 0)
+	}
+}
+
+func testPDVariableSubscribe(t *testing.T, init bool) {
+	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer cluster.Terminate(t)
+
+	if init {
+		cli := cluster.RandClient()
+		_, err := cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+		require.NoError(t, err)
+	}
+
+	pdvariable.Init(func() *clientv3.Client {
+		return cluster.RandClient()
+	})
+	defer pdvariable.Stop()
+
+	// wait for first load finish
+	time.Sleep(time.Millisecond * 100)
+
+	sub := pdvariable.Subscribe()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cli := cluster.RandClient()
+		_, err := cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknow", "false")
+		require.NoError(t, err)
+		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+		require.NoError(t, err)
+		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknow", "abcd")
+		require.NoError(t, err)
+		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+		require.NoError(t, err)
+	}()
+
+	for i, v := range []bool{true, false} {
+		vars := <-sub
+		require.Equal(t, v, vars.EnableTopSQL, "idx: %v", i)
+	}
+}

--- a/config/service.go
+++ b/config/service.go
@@ -47,7 +47,10 @@ func handleModifyConfig(c *gin.Context) error {
 			if !ok {
 				return fmt.Errorf("%v config value is invalid: %v", k, v)
 			}
-			return handleContinueProfilingConfigModify(m)
+			err := handleContinueProfilingConfigModify(m)
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("config %v not support modify or unknow", k)
 		}

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/genjidb/genji"
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/ng_monitoring/utils/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type testSuite struct {
+	tmpDir string
+	db     *genji.DB
+}
+
+func (ts *testSuite) setup(t *testing.T) {
+	var err error
+	ts.tmpDir, err = ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	ts.db = testutil.NewGenjiDB(t, ts.tmpDir)
+	GetDB = func() *genji.DB {
+		return ts.db
+	}
+	def := GetDefaultConfig()
+	StoreGlobalConfig(&def)
+	err = LoadConfigFromStorage(func() *genji.DB {
+		return ts.db
+	})
+	require.NoError(t, err)
+}
+
+func (ts *testSuite) close(t *testing.T) {
+	err := ts.db.Close()
+	err = os.RemoveAll(ts.tmpDir)
+	require.NoError(t, err)
+}
+
+func TestHTTPService(t *testing.T) {
+	ts := testSuite{}
+	ts.setup(t)
+	defer ts.close(t)
+	addr := setupHTTPService(t)
+	resp, err := http.Get("http://" + addr + "/config")
+	require.NoError(t, err)
+	data, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	cfg := Config{}
+	require.Equal(t, len(data) > 10, true)
+	err = json.Unmarshal(data, &cfg)
+	require.NoError(t, err)
+
+	res, err := http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(`{"continuous_profiling": {"enable": true,"profile_seconds":6,"interval_seconds":11}}`)))
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+	globalCfg := GetGlobalConfig()
+	require.Equal(t, true, globalCfg.ContinueProfiling.Enable)
+	require.Equal(t, 6, globalCfg.ContinueProfiling.ProfileSeconds)
+	require.Equal(t, 11, globalCfg.ContinueProfiling.IntervalSeconds)
+
+	// test for post invalid config
+	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(`{"continuous_profiling": {"enable": true,"profile_seconds":1000,"interval_seconds":11}}`)))
+	require.NoError(t, err)
+	require.Equal(t, 503, res.StatusCode)
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"message":"new config is invalid: {\"data_retention_seconds\":259200,\"enable\":true,\"interval_seconds\":11,\"profile_seconds\":1000,\"timeout_seconds\":120}","status":"error"}`, string(body))
+
+	// test empty body config
+	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(``)))
+	require.NoError(t, err)
+	require.Equal(t, 503, res.StatusCode)
+	body, err = ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"message":"EOF","status":"error"}`, string(body))
+
+	// test unknown config
+	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(`{"unknown_module": {"enable": true}}`)))
+	require.NoError(t, err)
+	require.Equal(t, 503, res.StatusCode)
+	body, err = ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"message":"config unknown_module not support modify or unknow","status":"error"}`, string(body))
+
+	globalCfg = GetGlobalConfig()
+	require.Equal(t, true, globalCfg.ContinueProfiling.Enable)
+	require.Equal(t, 6, globalCfg.ContinueProfiling.ProfileSeconds)
+	require.Equal(t, 11, globalCfg.ContinueProfiling.IntervalSeconds)
+}
+
+func setupHTTPService(t *testing.T) string {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	gin.SetMode(gin.ReleaseMode)
+	ng := gin.New()
+
+	ng.Use(gin.Recovery())
+	configGroup := ng.Group("/config")
+	HTTPService(configGroup)
+	httpServer := &http.Server{Handler: ng}
+
+	go func() {
+		if err = httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	return listener.Addr().String()
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/ugorji/go v1.2.6 // indirect
 	github.com/valyala/gozstd v1.14.2
 	github.com/wangjohn/quickselect v0.0.0-20161129230411-ed8402a42d5f
+	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738
 	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1071,6 +1071,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
+go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738 h1:lWF4f9Nypl1ZqSb4gLeh/DGvBYVaUYHuiB93teOmwgc=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -1352,6 +1354,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/utils/testutil/util.go
+++ b/utils/testutil/util.go
@@ -2,6 +2,9 @@ package testutil
 
 import (
 	"context"
+	"net"
+	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/dgraph-io/badger/v3"
@@ -21,4 +24,62 @@ func NewGenjiDB(t *testing.T, storagePath string) *genji.DB {
 	db, err := genji.New(context.Background(), engine)
 	require.NoError(t, err)
 	return db
+}
+
+type MockProfileServer struct {
+	Addr       string
+	Port       uint
+	HttpServer *http.Server
+}
+
+func CreateMockProfileServer(t *testing.T) *MockProfileServer {
+	s := &MockProfileServer{}
+	s.Start(t)
+	return s
+}
+
+func (s *MockProfileServer) Start(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	router := http.NewServeMux()
+	router.HandleFunc("/debug/pprof/profile", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("profile"))
+	})
+
+	router.HandleFunc("/debug/pprof/mutex", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("mutex"))
+	})
+
+	router.HandleFunc("/debug/pprof/goroutine", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("goroutine"))
+	})
+
+	router.HandleFunc("/debug/pprof/heap", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte("heap"))
+	})
+
+	httpServer := &http.Server{
+		Handler: router,
+	}
+	go func() {
+		if err = httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+	var port string
+	s.Addr, port, err = net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 64)
+	require.NoError(t, err)
+	s.Port = uint(p)
+	s.HttpServer = httpServer
+}
+
+func (s *MockProfileServer) Stop(t *testing.T) {
+	err := s.HttpServer.Close()
+	require.NoError(t, err)
 }

--- a/utils/testutil/util.go
+++ b/utils/testutil/util.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/genjidb/genji"
+	"github.com/genjidb/genji/engine/badgerengine"
+	"github.com/stretchr/testify/require"
+)
+
+func NewGenjiDB(t *testing.T, storagePath string) *genji.DB {
+	opts := badger.DefaultOptions(storagePath).
+		WithZSTDCompressionLevel(3).
+		WithBlockSize(8 * 1024).
+		WithValueThreshold(128 * 1024)
+
+	engine, err := badgerengine.NewEngine(opts)
+	require.NoError(t, err)
+	db, err := genji.New(context.Background(), engine)
+	require.NoError(t, err)
+	return db
+}


### PR DESCRIPTION

```shell
▶ make test
Running test
?       github.com/pingcap/ng_monitoring/component/conprof      [no test files]
ok      github.com/pingcap/ng_monitoring/component/conprof/http 1.603s  coverage: 77.6% of statements
ok      github.com/pingcap/ng_monitoring/component/conprof/meta 0.041s  coverage: [no statements]
ok      github.com/pingcap/ng_monitoring/component/conprof/scrape       4.717s  coverage: 90.2% of statements
ok      github.com/pingcap/ng_monitoring/component/conprof/store        0.318s  coverage: 83.9% of statements
?       github.com/pingcap/ng_monitoring/component/conprof/util [no test files]
ok      github.com/pingcap/ng_monitoring/component/topology     0.540s  coverage: 58.9% of statements
?       github.com/pingcap/ng_monitoring/component/topsql       [no test files]
?       github.com/pingcap/ng_monitoring/component/topsql/query [no test files]
?       github.com/pingcap/ng_monitoring/component/topsql/service       [no test files]
?       github.com/pingcap/ng_monitoring/component/topsql/store [no test files]
?       github.com/pingcap/ng_monitoring/component/topsql/subscriber    [no test files]
ok      github.com/pingcap/ng_monitoring/config 0.273s  coverage: 84.5% of statements
ok      github.com/pingcap/ng_monitoring/config/pdvariable      0.927s  coverage: 75.3% of statements
?       github.com/pingcap/ng_monitoring/database       [no test files]
?       github.com/pingcap/ng_monitoring/database/document      [no test files]
?       github.com/pingcap/ng_monitoring/database/timeseries    [no test files]
?       github.com/pingcap/ng_monitoring/service        [no test files]
?       github.com/pingcap/ng_monitoring/service/http   [no test files]
?       github.com/pingcap/ng_monitoring/utils  [no test files]
?       github.com/pingcap/ng_monitoring/utils/testutil [no test files]
```