### PR TITLE
*: add golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 log
 *.log
 coverage.txt
+tools/bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,40 @@
+run:
+  timeout: 10m
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - ineffassign
+    - typecheck
+    - varcheck
+    - unused
+    - structcheck
+    - deadcode
+    - gosimple
+    - goimports
+    - errcheck
+    - staticcheck
+    - stylecheck
+    - gosec
+    - asciicheck
+    - bodyclose
+    - exportloopref
+    - rowserrcheck
+    - unconvert
+    - makezero
+    - durationcheck
+    - prealloc
+
+linters-settings:
+  staticcheck:
+    checks: ["S1002","S1004","S1007","S1009","S1010","S1012","S1019","S1020","S1021","S1024","S1030","SA2*","SA3*","SA4009","SA5*","SA6000","SA6001","SA6005", "-SA2002"]
+  stylecheck:
+    checks: ["-ST1003"]
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
+        - rowserrcheck
+        - makezero

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,9 @@ test:
 	@echo "Running test"
 	@export log_level=info; export TZ='Asia/Shanghai'; \
 	$(GOTEST) -cover $(PACKAGES_TESTS) -coverprofile=coverage.txt
+
+lint: tools/bin/golangci-lint
+	GO111MODULE=on tools/bin/golangci-lint run -v $$($(PACKAGE_DIRECTORIES)) --config .golangci.yml
+
+tools/bin/golangci-lint:
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.41.1

--- a/component/conprof/http/api.go
+++ b/component/conprof/http/api.go
@@ -61,7 +61,7 @@ func handleSingleProfileView(c *gin.Context) {
 		return
 	}
 	c.Writer.WriteHeader(http.StatusOK)
-	c.Writer.Write(result)
+	_, _ = c.Writer.Write(result)
 }
 
 func handleDownload(c *gin.Context) {

--- a/component/conprof/http/api_test.go
+++ b/component/conprof/http/api_test.go
@@ -42,6 +42,7 @@ func (ts *testSuite) setup(t *testing.T) {
 
 func (ts *testSuite) close(t *testing.T) {
 	err := ts.db.Close()
+	require.NoError(t, err)
 	err = os.RemoveAll(ts.tmpDir)
 	require.NoError(t, err)
 }
@@ -92,6 +93,8 @@ func testAPIGroupProfiles(t *testing.T, httpAddr string) int64 {
 	require.Equal(t, 200, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+	err = resp.Body.Close()
+	require.NoError(t, err)
 
 	var groupProfiles []GroupProfiles
 	err = json.Unmarshal(body, &groupProfiles)
@@ -109,6 +112,8 @@ func testAPIGroupProfileDetail(t *testing.T, httpAddr string, ts int64, componen
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	err = resp.Body.Close()
 	require.NoError(t, err)
 
 	var groupProfileDetail GroupProfileDetail
@@ -139,6 +144,8 @@ func testAPISingleProfileView(t *testing.T, httpAddr string, ts int64, component
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, "profile", string(body))
+		err = resp.Body.Close()
+		require.NoError(t, err)
 	}
 }
 
@@ -155,6 +162,9 @@ func testAPIDownload(t *testing.T, httpAddr string, ts int64, components []topol
 		require.Equal(t, 200, resp.StatusCode)
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
+		err = resp.Body.Close()
+		require.NoError(t, err)
+
 		zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
 		require.NoError(t, err)
 
@@ -204,6 +214,8 @@ func testAPIComponent(t *testing.T, httpAddr string, components []topology.Compo
 	require.Equal(t, 200, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+	err = resp.Body.Close()
+	require.NoError(t, err)
 
 	var comps []topology.Component
 	err = json.Unmarshal(body, &comps)
@@ -226,6 +238,8 @@ func testAPIEstimateSize(t *testing.T, httpAddr string, components []topology.Co
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	err = resp.Body.Close()
 	require.NoError(t, err)
 
 	var estimateSize EstimateSize
@@ -274,6 +288,8 @@ func testErrorRequest(t *testing.T, httpAddr string) {
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, ca.body, string(body), ca.api)
+		err = resp.Body.Close()
+		require.NoError(t, err)
 	}
 }
 

--- a/component/conprof/http/svg.go
+++ b/component/conprof/http/svg.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/goccy/go-graphviz"
+	graphviz "github.com/goccy/go-graphviz"
 	"github.com/google/pprof/driver"
 	"github.com/google/pprof/profile"
 )

--- a/component/conprof/scrape/scrape.go
+++ b/component/conprof/scrape/scrape.go
@@ -2,7 +2,6 @@ package scrape
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -160,18 +159,6 @@ func (s *Scraper) scrape(ctx context.Context, w io.Writer) error {
 
 	_, err = w.Write(b)
 	return err
-}
-
-func (s *Scraper) tryUnzip(data []byte) []byte {
-	gz, err := gzip.NewReader(bytes.NewBuffer(data))
-	if err != nil {
-		return data
-	}
-	v, err := ioutil.ReadAll(gz)
-	if err != nil {
-		return data
-	}
-	return v
 }
 
 // Target refers to a singular HTTP or HTTPS endpoint.

--- a/component/conprof/store/store.go
+++ b/component/conprof/store/store.go
@@ -33,10 +33,9 @@ type ProfileStorage struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	sync.Mutex
-	db           *genji.DB
-	metaCache    map[meta.ProfileTarget]*meta.TargetInfo
-	idAllocator  int64
-	aliveTargets []meta.ProfileTarget
+	db          *genji.DB
+	metaCache   map[meta.ProfileTarget]*meta.TargetInfo
+	idAllocator int64
 }
 
 func NewProfileStorage(db *genji.DB) (*ProfileStorage, error) {
@@ -61,6 +60,9 @@ func (s *ProfileStorage) init() error {
 		return err
 	}
 	allTargets, allInfos, err := s.loadAllTargetsFromTable()
+	if err != nil {
+		return err
+	}
 	for i, target := range allTargets {
 		info := allInfos[i]
 		s.metaCache[target] = &info
@@ -229,7 +231,7 @@ func (s *ProfileStorage) QueryGroupProfiles(param *meta.BasicQueryParam) ([]meta
 	wg.Wait()
 	close(resultCh)
 
-	var result []meta.ProfileList
+	result := make([]meta.ProfileList, 0, len(resultCh))
 	for qr := range resultCh {
 		if qr.err != nil {
 			return nil, qr.err

--- a/component/domain/client.go
+++ b/component/domain/client.go
@@ -86,7 +86,7 @@ func (cm *ClientMaintainer) Close() {
 	select {
 	case <-cm.initialized:
 		etcdCli := cm.etcdCli.Load()
-		etcdCli.(*clientv3.Client).Close()
+		_ = etcdCli.(*clientv3.Client).Close()
 	default:
 		return
 	}

--- a/component/topology/topology.go
+++ b/component/topology/topology.go
@@ -30,9 +30,7 @@ func GetCurrentComponent() []Component {
 		return nil
 	}
 	components := make([]Component, 0, len(discover.components))
-	for _, comp := range discover.components {
-		components = append(components, comp)
-	}
+	components = append(components, discover.components...)
 	return components
 }
 

--- a/component/topsql/mock/pubsub.go
+++ b/component/topsql/mock/pubsub.go
@@ -23,9 +23,6 @@ type MockPubSub struct {
 	listener net.Listener
 	server   *grpc.Server
 
-	tidbService tidbService
-	tikvService tikvService
-
 	tidbAccessor chan tidbStreamAccessor
 	tikvAccessor chan tikvStreamAccessor
 }

--- a/component/topsql/subscriber/default_subscriber_test.go
+++ b/component/topsql/subscriber/default_subscriber_test.go
@@ -2,13 +2,14 @@ package subscriber_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pingcap/ng-monitoring/component/topology"
 	"github.com/pingcap/ng-monitoring/component/topsql/mock"
 	"github.com/pingcap/ng-monitoring/component/topsql/subscriber"
 	"github.com/pingcap/ng-monitoring/config"
 	"github.com/pingcap/ng-monitoring/config/pdvariable"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestDefaultSubscriberBasic(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -277,6 +277,7 @@ func TestConfigPersist(t *testing.T) {
 	err = LoadConfigFromStorage(func() *genji.DB {
 		return db
 	})
+	require.NoError(t, err)
 	curCfg := GetGlobalConfig()
 	require.Equal(t, true, curCfg.ContinueProfiling.Enable)
 	require.Equal(t, 100, curCfg.ContinueProfiling.IntervalSeconds)

--- a/config/pdvariable/pdvariable.go
+++ b/config/pdvariable/pdvariable.go
@@ -29,7 +29,6 @@ func Init(do *domain.Domain) {
 		cfg: DefaultPDVariable(),
 	}
 	go utils.GoWithRecovery(loader.start, nil)
-	return
 }
 
 type PDVariable struct {
@@ -174,9 +173,7 @@ func (l *variableLoader) loadAllGlobalConfig(ctx context.Context) (*PDVariable, 
 }
 
 func (l *variableLoader) parseGlobalConfig(key, value string, cfg *PDVariable) error {
-	if strings.HasPrefix(key, GlobalConfigPath) {
-		key = key[len(GlobalConfigPath):]
-	}
+	key = strings.TrimPrefix(key, GlobalConfigPath)
 	switch key {
 	case "enable_resource_metering":
 		v, err := strconv.ParseBool(value)

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -38,6 +38,7 @@ func (ts *testSuite) setup(t *testing.T) {
 
 func (ts *testSuite) close(t *testing.T) {
 	err := ts.db.Close()
+	require.NoError(t, err)
 	err = os.RemoveAll(ts.tmpDir)
 	require.NoError(t, err)
 }
@@ -51,6 +52,8 @@ func TestHTTPService(t *testing.T) {
 	require.NoError(t, err)
 	data, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+	err = resp.Body.Close()
+	require.NoError(t, err)
 	cfg := Config{}
 	require.Equal(t, len(data) > 10, true)
 	err = json.Unmarshal(data, &cfg)
@@ -63,6 +66,8 @@ func TestHTTPService(t *testing.T) {
 	require.Equal(t, true, globalCfg.ContinueProfiling.Enable)
 	require.Equal(t, 6, globalCfg.ContinueProfiling.ProfileSeconds)
 	require.Equal(t, 11, globalCfg.ContinueProfiling.IntervalSeconds)
+	err = res.Body.Close()
+	require.NoError(t, err)
 
 	// test for post invalid config
 	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(`{"continuous_profiling": {"enable": true,"profile_seconds":1000,"interval_seconds":11}}`)))
@@ -71,6 +76,8 @@ func TestHTTPService(t *testing.T) {
 	body, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, `{"message":"new config is invalid: {\"data_retention_seconds\":259200,\"enable\":true,\"interval_seconds\":11,\"profile_seconds\":1000,\"timeout_seconds\":120}","status":"error"}`, string(body))
+	err = res.Body.Close()
+	require.NoError(t, err)
 
 	// test empty body config
 	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(``)))
@@ -79,6 +86,8 @@ func TestHTTPService(t *testing.T) {
 	body, err = ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, `{"message":"EOF","status":"error"}`, string(body))
+	err = res.Body.Close()
+	require.NoError(t, err)
 
 	// test unknown config
 	res, err = http.Post("http://"+addr+"/config", "application/json", bytes.NewReader([]byte(`{"unknown_module": {"enable": true}}`)))
@@ -87,6 +96,8 @@ func TestHTTPService(t *testing.T) {
 	body, err = ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, `{"message":"config unknown_module not support modify or unknow","status":"error"}`, string(body))
+	err = res.Body.Close()
+	require.NoError(t, err)
 
 	globalCfg = GetGlobalConfig()
 	require.Equal(t, true, globalCfg.ContinueProfiling.Enable)

--- a/tests/mock.go
+++ b/tests/mock.go
@@ -66,15 +66,14 @@ func (s *MockTiDBServer) Subscribe(req *tipb.TopSQLSubRequest, stream tipb.TopSQ
 			if !changed {
 				continue
 			}
-			if records != nil {
-				for _, record := range records {
-					if err := stream.Send(&tipb.TopSQLSubResponse{
-						RespOneof: &tipb.TopSQLSubResponse_Record{
-							Record: &record,
-						},
-					}); err != nil {
-						panic(err)
-					}
+			for i := range records {
+				record := &records[i]
+				if err := stream.Send(&tipb.TopSQLSubResponse{
+					RespOneof: &tipb.TopSQLSubResponse_Record{
+						Record: record,
+					},
+				}); err != nil {
+					panic(err)
 				}
 			}
 		}
@@ -136,11 +135,9 @@ func (s *MockTiKVServer) Subscribe(req *rua.ResourceMeteringRequest, stream rua.
 			if !changed {
 				continue
 			}
-			if records != nil {
-				for _, record := range records {
-					if err := stream.Send(record); err != nil {
-						panic(err)
-					}
+			for _, record := range records {
+				if err := stream.Send(record); err != nil {
+					panic(err)
 				}
 			}
 		}

--- a/tests/topsql_test.go
+++ b/tests/topsql_test.go
@@ -75,6 +75,7 @@ func (s *testTopSQLSuite) SetupSuite() {
 	// init local mock tidb server
 	s.tidbServer = NewMockTiDBServer()
 	tidbAddr, err := s.tidbServer.Listen()
+	s.NoError(err)
 	s.tidbAddr = tidbAddr
 	arr := strings.Split(tidbAddr, ":")
 	tidbTestIp := arr[0]

--- a/utils/retry_test.go
+++ b/utils/retry_test.go
@@ -2,10 +2,11 @@ package utils_test
 
 import (
 	"context"
-	"github.com/pingcap/ng-monitoring/utils"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/pingcap/ng-monitoring/utils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithRetry(t *testing.T) {
@@ -47,10 +48,7 @@ func TestWithRetryDoneMidway(t *testing.T) {
 		require.Equal(t, u, executed)
 		executed += 1
 
-		if u == 3 {
-			return true
-		}
-		return false
+		return u == 3
 	})
 	require.Equal(t, executed, uint(4))
 }
@@ -98,10 +96,7 @@ func TestWithRetryBackoffDoneMidway(t *testing.T) {
 		require.Equal(t, u, executed)
 		executed += 1
 
-		if u == 3 {
-			return true
-		}
-		return false
+		return u == 3
 	})
 	require.Equal(t, executed, uint(4))
 }

--- a/utils/testutil/util.go
+++ b/utils/testutil/util.go
@@ -55,22 +55,26 @@ func (s *MockProfileServer) Start(t *testing.T) {
 	router := http.NewServeMux()
 	router.HandleFunc("/debug/pprof/profile", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
-		writer.Write([]byte("profile"))
+		_, err := writer.Write([]byte("profile"))
+		require.NoError(t, err)
 	})
 
 	router.HandleFunc("/debug/pprof/mutex", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
-		writer.Write([]byte("mutex"))
+		_, err := writer.Write([]byte("mutex"))
+		require.NoError(t, err)
 	})
 
 	router.HandleFunc("/debug/pprof/goroutine", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
-		writer.Write([]byte("goroutine"))
+		_, err := writer.Write([]byte("goroutine"))
+		require.NoError(t, err)
 	})
 
 	router.HandleFunc("/debug/pprof/heap", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
-		writer.Write([]byte("heap"))
+		_, err := writer.Write([]byte("heap"))
+		require.NoError(t, err)
 	})
 
 	httpServer := &http.Server{
@@ -274,13 +278,13 @@ func SetupCert() (serverTLSConf *tls.Config, clientTLSConf *tls.Config, err erro
 		return nil, nil, err
 	}
 
-	serverTLSConf = &tls.Config{
+	serverTLSConf = &tls.Config{ // nolint:gosec
 		Certificates: []tls.Certificate{serverCert},
 	}
 
 	certpool := x509.NewCertPool()
 	certpool.AppendCertsFromPEM(caPEM.Bytes())
-	clientTLSConf = &tls.Config{
+	clientTLSConf = &tls.Config{ // nolint:gosec
 		RootCAs: certpool,
 	}
 


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4

### What is changed and how it works?


```shell
▶ make lint
GO111MODULE=on tools/bin/golangci-lint run -v $(go list ./...| grep -E "github.com/pingcap/ng-monitoring/" | sed 's|github.com/pingcap/ng-monitoring/||') --config .golangci.yml
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 21 linters: [asciicheck bodyclose deadcode durationcheck errcheck exportloopref goimports gosec gosimple ineffassign makezero misspell prealloc rowserrcheck staticcheck structcheck stylecheck typecheck unconvert unused varcheck]
INFO [loader] Go packages loading at mode 575 (files|imports|exports_file|name|types_sizes|compiled_files|deps) took 1.016317274s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 9.514185ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 55, after processing: 0
INFO [runner] Processors filtering stat (out/in): cgo: 55/55, filename_unadjuster: 55/55, nolint: 0/2, skip_dirs: 55/55, exclude: 55/55, skip_files: 55/55, path_prettifier: 55/55, autogenerated_exclude: 55/55, identifier_marker: 55/55, exclude-rules: 2/55
INFO [runner] processing took 3.574576ms with stages: nolint: 1.357858ms, identifier_marker: 918.032µs, path_prettifier: 572.218µs, autogenerated_exclude: 409.829µs, exclude-rules: 225.766µs, skip_dirs: 63.106µs, cgo: 15.483µs, filename_unadjuster: 5.693µs, max_same_issues: 1.674µs, uniq_by_line: 928ns, path_shortener: 729ns, diff: 662ns, max_from_linter: 476ns, source_code: 419ns, skip_files: 359ns, exclude: 336ns, severity-rules: 311ns, max_per_file_from_linter: 277ns, sort_results: 273ns, path_prefixer: 147ns
INFO [runner] linters took 188.779209ms with stages: goanalysis_metalinter: 185.055838ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 14 samples, avg is 81.9MB, max is 139.0MB
INFO Execution took 1.233832538s

```