### PR TITLE
fix test

### DIFF
--- a/component/domain/domain_test.go
+++ b/component/domain/domain_test.go
@@ -59,6 +59,7 @@ func TestDomain(t *testing.T) {
 
 func TestClientMaintainer(t *testing.T) {
 	cfg := config.GetDefaultConfig()
+	cfg.PD.Endpoints = nil
 	config.StoreGlobalConfig(&cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 	_, _, err := createClientWithRetry(ctx)

--- a/component/topology/topology_test.go
+++ b/component/topology/topology_test.go
@@ -45,6 +45,7 @@ func TestTopology(t *testing.T) {
 	defer mockPD.Close(t)
 
 	cfg := config.GetDefaultConfig()
+	cfg.PD.Endpoints = nil
 	cfg.AdvertiseAddress = "10.0.1.8:12020"
 	_, err := domain.CreatePDClient(&cfg)
 	require.NotNil(t, err)


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->


### What is changed and how it works?
Fix test which import by #101 

```shell
--- FAIL: TestClientMaintainer (0.15s)
    domain_test.go:74:
                Error Trace:    domain_test.go:74
                Error:          Not equal:
                                expected: "need specify pd endpoints"
                                actual  : "Get \"http://127.0.0.1:2379/pd/api/v1/health\": dial tcp 127.0.0.1:2379: connect: connection refused"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -need specify pd endpoints
                                +Get "http://127.0.0.1:2379/pd/api/v1/health": dial tcp 127.0.0.1:2379: connect: connection refused
                Test:           TestClientMaintainer



--- FAIL: TestTopology (0.52s)
    topology_test.go:51:
                Error Trace:    topology_test.go:51
                Error:          Not equal:
                                expected: "need specify pd endpoints"
                                actual  : "Get \"http://127.0.0.1:2379/pd/api/v1/health\": dial tcp 127.0.0.1:2379: connect: connection refused"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -need specify pd endpoints
                                +Get "http://127.0.0.1:2379/pd/api/v1/health": dial tcp 127.0.0.1:2379: connect: connection refused
                Test:           TestTopology
```
