### PR TITLE
topsql: fix instances output more than given time range (cherry-pick #104)

### DIFF
--- a/component/topsql/query/default_query.go
+++ b/component/topsql/query/default_query.go
@@ -199,6 +199,9 @@ func (dq *DefaultQuery) Summary(startSecs, endSecs, windowSecs, top int, instanc
 }
 
 func (dq *DefaultQuery) Instances(startSecs, endSecs int, fill *[]InstanceItem) error {
+	if startSecs > endSecs {
+		return nil
+	}
 	return dq.fetchInstancesFromTSDB(startSecs, endSecs, fill)
 }
 
@@ -236,6 +239,7 @@ func (dq *DefaultQuery) fetchRecordsFromTSDB(name string, startSecs int, endSecs
 	reqQuery.Set("start", strconv.Itoa(startSecs))
 	reqQuery.Set("end", strconv.Itoa(endSecs))
 	reqQuery.Set("step", strconv.Itoa(windowSecs))
+	reqQuery.Set("nocache", "1")
 	req.URL.RawQuery = reqQuery.Encode()
 	req.Header.Set("Accept", "application/json")
 
@@ -260,15 +264,28 @@ func (dq *DefaultQuery) fetchInstancesFromTSDB(startSecs, endSecs int, fill *[]I
 
 	defer bytesP.Put(bufResp)
 	defer headerP.Put(header)
-	req, err := http.NewRequest("GET", "/api/v1/query_range", nil)
+	req, err := http.NewRequest("GET", "/api/v1/query", nil)
 	if err != nil {
 		return err
 	}
 	reqQuery := req.URL.Query()
-	reqQuery.Set("query", "last_over_time(instance)")
-	reqQuery.Set("start", strconv.Itoa(startSecs))
-	reqQuery.Set("end", strconv.Itoa(endSecs))
-	reqQuery.Set("step", strconv.Itoa(endSecs-startSecs))
+
+	// Data:
+	// t1  t2  t3  t4  t5  t6  t7  t8  t9
+	// v1  v2  v3  v4  v5  v6  v7  v8  v9
+	//
+	// Given startSecs = t3, endSecs = t6, to calculate v3 || v4 || v5 || v6
+	//
+	// The exec model for vm is lookbehind. So we can set time = endSecs, window = endSecs-startSecs+1,
+	// to get the point that exists from v3 to v6.
+	//
+	// t1  t2  t3  t4  t5  t6  t7  t8  t9
+	// v1  v2  v3  v4  v5  v6  v7  v8  v9
+	//         ^            ^
+	//         |   window   |
+	reqQuery.Set("query", fmt.Sprintf("last_over_time(instance[%ds])", endSecs-startSecs+1))
+	reqQuery.Set("time", strconv.Itoa(endSecs))
+	reqQuery.Set("nocache", "1")
 	req.URL.RawQuery = reqQuery.Encode()
 	req.Header.Set("Accept", "application/json")
 	respR := utils.NewRespWriter(bufResp, header)
@@ -304,12 +321,11 @@ func (dq *DefaultQuery) fetchSumFromTSDB(name string, startSecs, endSecs int, in
 	defer bytesP.Put(bufResp)
 	defer headerP.Put(header)
 
-	req, err := http.NewRequest("GET", "/api/v1/query_range", nil)
+	req, err := http.NewRequest("GET", "/api/v1/query", nil)
 	if err != nil {
 		return err
 	}
 	reqQuery := req.URL.Query()
-	reqQuery.Set("query", fmt.Sprintf("sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"})", name, instance, instanceType))
 
 	// Data:
 	// t1  t2  t3  t4  t5  t6  t7  t8  t9
@@ -317,16 +333,16 @@ func (dq *DefaultQuery) fetchSumFromTSDB(name string, startSecs, endSecs int, in
 	//
 	// Given startSecs = t3, endSecs = t6, to calculate v3 + v4 + v5 + v6
 	//
-	// The exec model for vm is lookbehind. So we can set start = endSecs, end = endSecs, step = endSecs-startSecs+1,
+	// The exec model for vm is lookbehind. So we can set time = endSecs, window = endSecs-startSecs+1,
 	// to get the point that sum up from v3 to v6.
 	//
 	// t1  t2  t3  t4  t5  t6  t7  t8  t9
 	// v1  v2  v3  v4  v5  v6  v7  v8  v9
 	//         ^            ^
-	//         | -- step -- |
-	reqQuery.Set("start", strconv.Itoa(endSecs))
-	reqQuery.Set("end", strconv.Itoa(endSecs))
-	reqQuery.Set("step", strconv.Itoa(endSecs-startSecs+1))
+	//         |   window   |
+	reqQuery.Set("query", fmt.Sprintf("sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%ds])", name, instance, instanceType, endSecs-startSecs+1))
+	reqQuery.Set("time", strconv.Itoa(endSecs))
+	reqQuery.Set("nocache", "1")
 	req.URL.RawQuery = reqQuery.Encode()
 	req.Header.Set("Accept", "application/json")
 
@@ -339,22 +355,17 @@ func (dq *DefaultQuery) fetchSumFromTSDB(name string, startSecs, endSecs int, in
 		return errors.New(errStr)
 	}
 
-	var recordsResponse recordsMetricResp
-	if err = json.Unmarshal(respR.Body.Bytes(), &recordsResponse); err != nil {
+	var sumResponse sumMetricResp
+	if err = json.Unmarshal(respR.Body.Bytes(), &sumResponse); err != nil {
 		return err
 	}
 
-	for _, result := range recordsResponse.Data.Results {
-		if len(result.Values) == 0 {
+	for _, result := range sumResponse.Data.Results {
+		if len(result.Value) < 2 {
 			continue
 		}
 
-		pair := result.Values[0]
-		if len(pair) < 2 {
-			continue
-		}
-
-		v, ok := pair[1].(string)
+		v, ok := result.Value[1].(string)
 		if !ok {
 			continue
 		}

--- a/component/topsql/query/model.go
+++ b/component/topsql/query/model.go
@@ -90,3 +90,23 @@ type instancesMetricRespDataResultMetric struct {
 	Instance     string `json:"instance"`
 	InstanceType string `json:"instance_type"`
 }
+
+type sumMetricResp struct {
+	Status string            `json:"status"`
+	Data   sumMetricRespData `json:"data"`
+}
+
+type sumMetricRespData struct {
+	ResultType string                    `json:"resultType"`
+	Results    []sumMetricRespDataResult `json:"result"`
+}
+
+type sumMetricRespDataResult struct {
+	Metric sumMetricRespDataResultMetric `json:"metric"`
+	Value  []interface{}                 `json:"value"`
+}
+
+type sumMetricRespDataResultMetric struct {
+	SQLDigest  string `json:"sql_digest"`
+	PlanDigest string `json:"plan_digest"`
+}

--- a/component/topsql/subscriber/scraper.go
+++ b/component/topsql/subscriber/scraper.go
@@ -57,8 +57,11 @@ func (s *Scraper) Close() {
 }
 
 func (s *Scraper) Run() {
-	defer s.cancel()
 	log.Info("starting to scrape top SQL from the component", zap.Any("component", s.component))
+	defer func() {
+		s.cancel()
+		log.Info("stop scraping top SQL from the component", zap.Any("component", s.component))
+	}()
 
 	switch s.component.Name {
 	case topology.ComponentTiDB:

--- a/component/topsql/topsql_test.go
+++ b/component/topsql/topsql_test.go
@@ -93,27 +93,24 @@ func (s *testTopSQLSuite) TestInstances() {
 	var r []query.InstanceItem
 
 	r = nil
-	err = s.dq.Instances(int(now-41), int(now-40), &r)
+	err = s.dq.Instances(int(now-40), int(now-40), &r)
 	s.NoError(err)
-
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10081",
 		InstanceType: "tidb",
 	}})
 
 	r = nil
-	err = s.dq.Instances(int(now-21), int(now-20), &r)
+	err = s.dq.Instances(int(now-20), int(now-20), &r)
 	s.NoError(err)
-
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10080",
 		InstanceType: "tidb",
 	}})
 
 	r = nil
-	err = s.dq.Instances(int(now-1), int(now), &r)
+	err = s.dq.Instances(int(now), int(now), &r)
 	s.NoError(err)
-
 	sort.Slice(r, func(i, j int) bool { return r[i].Instance < r[j].Instance })
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10080",
@@ -126,7 +123,6 @@ func (s *testTopSQLSuite) TestInstances() {
 	r = nil
 	err = s.dq.Instances(int(now-40), int(now), &r)
 	s.NoError(err)
-
 	sort.Slice(r, func(i, j int) bool { return r[i].Instance < r[j].Instance })
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10080",
@@ -142,7 +138,6 @@ func (s *testTopSQLSuite) TestInstances() {
 	r = nil
 	err = s.dq.Instances(int(now-10), int(now), &r)
 	s.NoError(err)
-
 	sort.Slice(r, func(i, j int) bool { return r[i].Instance < r[j].Instance })
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10080",
@@ -155,13 +150,20 @@ func (s *testTopSQLSuite) TestInstances() {
 	r = nil
 	err = s.dq.Instances(int(now-40), int(now-20), &r)
 	s.NoError(err)
-
 	sort.Slice(r, func(i, j int) bool { return r[i].Instance < r[j].Instance })
 	s.Equal(r, []query.InstanceItem{{
 		Instance:     "127.0.0.1:10080",
 		InstanceType: "tidb",
 	}, {
 		Instance:     "127.0.0.1:10081",
+		InstanceType: "tidb",
+	}})
+
+	r = nil
+	err = s.dq.Instances(int(now-31), int(now-21), &r)
+	s.NoError(err)
+	s.Equal(r, []query.InstanceItem{{
+		Instance:     "127.0.0.1:10080",
 		InstanceType: "tidb",
 	}})
 }


### PR DESCRIPTION
cherry-pick #104 to release-5.4

---

Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

In master, if we want to query instances between ts 400 and ts 500, we query vm via `/api/v1/query_range` with arguments
```
query = last_over_time(instance[100s])
start = 400
end = 500
step = 100s
```
However, it will fetch instances from `(300, 500]`.

### What is changed and how it works?

In this patch, we query vm via `/api/v1/query` with arguments
```
query = last_over_time(instance[101s])
time = 500
```
Finally, It will fetch instances from `[400, 500]`.

Besides, `fetchSumFromTSDB` can also change to the same way.
