### PR TITLE
badger: add manual flatten to remove old version keys

### DIFF
--- a/database/document/document_test.go
+++ b/database/document/document_test.go
@@ -1,0 +1,47 @@
+package document
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pingcap/ng-monitoring/utils/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGC(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "ngm-test-.*")
+	require.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		require.NoError(t, err)
+	}()
+
+	db := testutil.NewBadgerDB(t, tmpDir)
+	ts, err := getLastFlattenTs(db)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), ts)
+
+	ts = time.Now().Unix()
+	err = storeLastFlattenTs(db, ts)
+	require.NoError(t, err)
+
+	lastTs, err := getLastFlattenTs(db)
+	require.NoError(t, err)
+	require.Equal(t, ts, lastTs)
+
+	require.False(t, needFlatten(db))
+	runGC(db)
+
+	lastTs = ts - int64(flattenInterval/time.Second)
+	err = storeLastFlattenTs(db, lastTs)
+	require.NoError(t, err)
+	require.True(t, needFlatten(db))
+
+	runGC(db)
+	lastFlattenTs, err := getLastFlattenTs(db)
+	require.NoError(t, err)
+	require.NotEqual(t, lastTs, lastFlattenTs)
+	require.Less(t, time.Now().Unix()-lastFlattenTs, int64(10))
+}

--- a/database/document/gc.go
+++ b/database/document/gc.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
+var (
 	lastFlattenTsKey = []byte("last_flatten_ts")
 	flattenInterval  = time.Hour * 24
 )

--- a/database/document/gc.go
+++ b/database/document/gc.go
@@ -1,0 +1,122 @@
+package document
+
+import (
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
+
+var (
+	lastFlattenTsKey = []byte("last_flatten_ts")
+	flattenInterval  = time.Hour * 24
+)
+
+func doGCLoop(db *badger.DB, closed chan struct{}) {
+	log.Info("badger start to run value log gc loop")
+	ticker := time.NewTicker(10 * time.Minute)
+	defer func() {
+		ticker.Stop()
+		log.Info("badger stop running value log gc loop")
+	}()
+
+	// run gc when started.
+	runGC(db)
+	for {
+		select {
+		case <-ticker.C:
+			runGC(db)
+		case <-closed:
+			return
+		}
+	}
+}
+
+func runGC(db *badger.DB) {
+	tryFlattenIfNeeded(db)
+	runValueLogGC(db)
+}
+
+func runValueLogGC(db *badger.DB) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			log.Error("panic when run badger value log",
+				zap.Reflect("r", r),
+				zap.Stack("stack trace"))
+		}
+	}()
+
+	// at most do 10 value log gc each time.
+	for i := 0; i < 10; i++ {
+		err := db.RunValueLogGC(0.1)
+		if err != nil {
+			if err == badger.ErrNoRewrite {
+				log.Info("badger has no value log need gc now")
+			} else {
+				log.Error("badger run value log gc failed", zap.Error(err))
+			}
+			return
+		}
+		log.Info("badger run value log gc success")
+	}
+}
+
+// tryFlattenIfNeeded try to do flatten if needed.
+// Flatten uses to remove the old version keys, otherwise, the value log gc won't release the disk space which occupied
+// by the old version keys.
+func tryFlattenIfNeeded(db *badger.DB) {
+	if !needFlatten(db) {
+		return
+	}
+	err := db.Flatten(runtime.NumCPU()/2 + 1)
+	if err != nil {
+		log.Error("badger flatten failed", zap.Error(err))
+		return
+	}
+	ts := time.Now().Unix()
+	err = storeLastFlattenTs(db, time.Now().Unix())
+	if err != nil {
+		log.Error("badger store last flatten ts failed", zap.Error(err))
+		return
+	}
+	log.Info("badger flatten success", zap.Int64("ts", ts))
+}
+
+func needFlatten(db *badger.DB) bool {
+	ts, err := getLastFlattenTs(db)
+	if err != nil {
+		log.Error("badger get last flatten ts failed", zap.Error(err))
+	}
+	interval := time.Now().Unix() - ts
+	return time.Duration(interval)*time.Second >= flattenInterval
+}
+
+func getLastFlattenTs(db *badger.DB) (int64, error) {
+	ts := int64(0)
+	err := db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(lastFlattenTsKey)
+		if err != nil {
+			if err == badger.ErrKeyNotFound {
+				return nil
+			}
+			return err
+		}
+		err = item.Value(func(val []byte) error {
+			ts, err = strconv.ParseInt(string(val), 10, 64)
+			return err
+		})
+		return err
+	})
+	return ts, err
+}
+
+func storeLastFlattenTs(db *badger.DB, ts int64) error {
+	return db.Update(func(txn *badger.Txn) error {
+		v := strconv.FormatInt(ts, 10)
+		return txn.Set(lastFlattenTsKey, []byte(v))
+	})
+}

--- a/database/document/gc.go
+++ b/database/document/gc.go
@@ -36,20 +36,20 @@ func doGCLoop(db *badger.DB, closed chan struct{}) {
 }
 
 func runGC(db *badger.DB) {
-	tryFlattenIfNeeded(db)
-	runValueLogGC(db)
-}
-
-func runValueLogGC(db *badger.DB) {
 	defer func() {
 		r := recover()
 		if r != nil {
-			log.Error("panic when run badger value log",
+			log.Error("panic when run badger gc",
 				zap.Reflect("r", r),
 				zap.Stack("stack trace"))
 		}
 	}()
 
+	tryFlattenIfNeeded(db)
+	runValueLogGC(db)
+}
+
+func runValueLogGC(db *badger.DB) {
 	// at most do 10 value log gc each time.
 	for i := 0; i < 10; i++ {
 		err := db.RunValueLogGC(0.1)

--- a/database/document/gc.go
+++ b/database/document/gc.go
@@ -78,7 +78,7 @@ func tryFlattenIfNeeded(db *badger.DB) {
 		return
 	}
 	ts := time.Now().Unix()
-	err = storeLastFlattenTs(db, time.Now().Unix())
+	err = storeLastFlattenTs(db, ts)
 	if err != nil {
 		log.Error("badger store last flatten ts failed", zap.Error(err))
 		return

--- a/database/document/gc.go
+++ b/database/document/gc.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
+const (
 	lastFlattenTsKey = []byte("last_flatten_ts")
 	flattenInterval  = time.Hour * 24
 )

--- a/utils/testutil/util.go
+++ b/utils/testutil/util.go
@@ -37,6 +37,17 @@ func NewGenjiDB(t *testing.T, storagePath string) *genji.DB {
 	return db
 }
 
+func NewBadgerDB(t *testing.T, storagePath string) *badger.DB {
+	opts := badger.DefaultOptions(storagePath).
+		WithZSTDCompressionLevel(3).
+		WithBlockSize(8 * 1024).
+		WithValueThreshold(128 * 1024)
+
+	engine, err := badgerengine.NewEngine(opts)
+	require.NoError(t, err)
+	return engine.DB
+}
+
 type MockProfileServer struct {
 	Addr       string
 	Port       uint


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #114

### What is changed and how it works?

Call badger `Flatten` API regularly.

`Flatten` uses to remove the old version keys, otherwise, the value log gc won't release the disk space which occupied
 by the old version keys.
