### PR TITLE
Revert "support profiling tiflash (#47)"

### DIFF
--- a/component/conprof/http/api.go
+++ b/component/conprof/http/api.go
@@ -117,7 +117,8 @@ func getProfileEstimateSize(component topology.Component) int {
 	case topology.ComponentTiKV:
 		return 200 * 1024 // profile size
 	case topology.ComponentTiFlash:
-		return 200 * 1024 // profile size
+		// TODO: remove this after TiFlash fix the profile bug.
+		return 0
 	}
 	return defaultProfileSize
 }

--- a/component/conprof/scrape/manager.go
+++ b/component/conprof/scrape/manager.go
@@ -180,6 +180,10 @@ func (m *Manager) startScrape(ctx context.Context, component topology.Component,
 	if !continueProfilingCfg.Enable {
 		return nil
 	}
+	// TODO: remove this after TiFlash fix the profile bug.
+	if component.Name == topology.ComponentTiFlash {
+		return nil
+	}
 	profilingConfig := m.getProfilingConfig(component)
 	cfg := config.GetGlobalConfig()
 	httpCfg := cfg.Security.GetHTTPClientConfig()

--- a/component/conprof/scrape/manager_test.go
+++ b/component/conprof/scrape/manager_test.go
@@ -89,6 +89,8 @@ func TestManager(t *testing.T) {
 					break
 				}
 			}
+			// TODO(crazycs): remove this after support tiflash
+			require.True(t, list.Target.Component != topology.ComponentTiFlash)
 			require.True(t, found, fmt.Sprintf("%#v", list))
 			for _, ts := range list.TsList {
 				require.True(t, ts >= param.Begin && ts <= param.End)
@@ -129,7 +131,8 @@ func TestManager(t *testing.T) {
 
 	// test for GetCurrentScrapeComponents
 	comp := manager.GetCurrentScrapeComponents()
-	require.Equal(t, len(comp), len(components))
+	// // TODO(crazycs): update this after support tiflash
+	require.Equal(t, len(comp), len(components)-1)
 
 	// test for topology changed.
 	mockServer2 := testutil.CreateMockProfileServer(t)


### PR DESCRIPTION
This reverts commit a0145fbc1e857171b2bc13fbe5fb71f13787e6f9.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

revert https://github.com/pingcap/ng-monitoring/pull/47

this is because https://github.com/pingcap/tics/issues/4172

Manual test:

![image](https://user-images.githubusercontent.com/26020263/157168780-f2318eed-c9e5-4a09-bd47-e8d9c7b72dd5.png)


### What is changed and how it works?
