### PR TITLE
pdvar: try best to notify and always return the latest value

### DIFF
--- a/component/topsql/subscriber/default_subscriber_test.go
+++ b/component/topsql/subscriber/default_subscriber_test.go
@@ -31,7 +31,7 @@ func TestDefaultSubscriberBasic(t *testing.T) {
 	go pubsub.Serve()
 	defer pubsub.Stop()
 
-	varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: true}
+	varSubscriber <- enable
 	topo := []topology.Component{{
 		Name:       "tidb",
 		IP:         ip,
@@ -39,4 +39,12 @@ func TestDefaultSubscriberBasic(t *testing.T) {
 	}}
 	topoSubscriber <- topo
 	checkTiDBScrape(t, fmt.Sprintf("%s:%d", ip, port), pubsub, store)
+}
+
+func enable() pdvariable.PDVariable {
+	return pdvariable.PDVariable{EnableTopSQL: true}
+}
+
+func disable() pdvariable.PDVariable {
+	return pdvariable.PDVariable{EnableTopSQL: false}
 }

--- a/component/topsql/subscriber/manager.go
+++ b/component/topsql/subscriber/manager.go
@@ -80,7 +80,8 @@ func (m *Manager) Run() {
 		}
 
 		select {
-		case vars := <-m.varSubscriber:
+		case getVars := <-m.varSubscriber:
+			vars := getVars()
 			if vars.EnableTopSQL && !m.enabled {
 				m.updateScrapers()
 				log.Info("Top SQL is enabled")

--- a/component/topsql/subscriber/manager_test.go
+++ b/component/topsql/subscriber/manager_test.go
@@ -61,7 +61,7 @@ func TestManagerBasic(t *testing.T) {
 	go pubsub.Serve()
 	defer pubsub.Stop()
 
-	ts.varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: true}
+	ts.varSubscriber <- enable
 	topo := []topology.Component{{
 		Name:       "tidb",
 		IP:         ip,
@@ -98,7 +98,7 @@ func TestManagerEnableAfterTopoIsReady(t *testing.T) {
 	}}
 	ts.topoSubscriber <- topo
 
-	ts.varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: true}
+	ts.varSubscriber <- enable
 	checkTiDBScrape(t, fmt.Sprintf("%s:%d", ip, port), pubsub, ts.store)
 }
 
@@ -114,7 +114,7 @@ func TestManagerTopoChange(t *testing.T) {
 	go pubsub.Serve()
 	defer pubsub.Stop()
 
-	ts.varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: true}
+	ts.varSubscriber <- enable
 	topo := []topology.Component{{
 		Name:       "tidb",
 		IP:         ip,
@@ -160,7 +160,7 @@ func TestManagerDisable(t *testing.T) {
 	go pubsub.Serve()
 	defer pubsub.Stop()
 
-	ts.varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: true}
+	ts.varSubscriber <- enable
 	topo := []topology.Component{{
 		Name:       "tidb",
 		IP:         ip,
@@ -185,5 +185,5 @@ func TestManagerDisable(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	})
-	ts.varSubscriber <- &pdvariable.PDVariable{EnableTopSQL: false}
+	ts.varSubscriber <- disable
 }

--- a/config/pdvariable/pdvariable_test.go
+++ b/config/pdvariable/pdvariable_test.go
@@ -3,7 +3,6 @@ package pdvariable_test
 import (
 	"context"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -45,23 +44,54 @@ func testPDVariableSubscribe(t *testing.T, init bool) {
 	time.Sleep(time.Millisecond * 100)
 
 	sub := pdvariable.Subscribe()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cli := cluster.RandClient()
-		_, err := cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknow", "false")
-		require.NoError(t, err)
-		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
-		require.NoError(t, err)
-		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknow", "abcd")
-		require.NoError(t, err)
-		_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
-		require.NoError(t, err)
-	}()
+	getVars := <-sub
+	require.Equal(t, false, getVars().EnableTopSQL)
 
-	for i, v := range []bool{true, false} {
-		vars := <-sub
-		require.Equal(t, v, vars.EnableTopSQL, "idx: %v", i)
-	}
+	cli := cluster.RandClient()
+	_, err := cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknown", "false")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"unknown", "abcd")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 100)
+	getVars = <-sub
+	require.Equal(t, true, getVars().EnableTopSQL)
+
+	cli = cluster.RandClient()
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 100)
+	getVars = <-sub
+	require.Equal(t, true, getVars().EnableTopSQL)
+
+	cli = cluster.RandClient()
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 100)
+	getVars = <-sub
+	require.Equal(t, true, getVars().EnableTopSQL)
+
+	cli = cluster.RandClient()
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "true")
+	require.NoError(t, err)
+	_, err = cli.Put(context.Background(), pdvariable.GlobalConfigPath+"enable_resource_metering", "false")
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 100)
+	getVars = <-sub
+	require.Equal(t, false, getVars().EnableTopSQL)
 }

--- a/tests/topsql_test.go
+++ b/tests/topsql_test.go
@@ -107,7 +107,7 @@ func (s *testTopSQLSuite) SetupSuite() {
 	s.cfgCh = make(config.Subscriber)
 	err = topsql.Init(&cfg, s.cfgCh, document.Get(), timeseries.InsertHandler, timeseries.SelectHandler, s.topCh, s.varCh)
 	s.NoError(err)
-	s.varCh <- &pdvariable.PDVariable{EnableTopSQL: true}
+	s.varCh <- enable
 	time.Sleep(100 * time.Millisecond)
 	s.topCh <- []topology.Component{{
 		Name:       topology.ComponentTiDB,
@@ -510,4 +510,8 @@ func (s *testTopSQLSuite) encodeTag(sql, plan []byte, label tipb.ResourceGroupTa
 	})
 	s.NoError(err)
 	return b
+}
+
+func enable() pdvariable.PDVariable {
+	return pdvariable.PDVariable{EnableTopSQL: true}
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?
1. A new pd variable subscriber cannot get any notifications if the variable doesn't change after the subscription, then the subscriber will never know what the variable is.
2. If the variable changes a lot and a subscriber is too busy to receive notifications, the subscriber will not know the latest variable.

### What is changed and how it works?
1. Notify subscribers when registering
2. Send a function instead of a value, so the notifier can return the latest variable via that function