### PR TITLE
turn off badger's prefetch and tuning for memory usage

### DIFF
--- a/database/document/document.go
+++ b/database/document/document.go
@@ -18,12 +18,17 @@ var documentDB *genji.DB
 var closeCh chan struct{}
 
 func Init(cfg *config.Config) {
+	badger.DefaultIteratorOptions.PrefetchValues = false
+
 	dataPath := path.Join(cfg.Storage.Path, "docdb")
 	l, _ := initLogger(cfg)
 	opts := badger.DefaultOptions(dataPath).
 		WithZSTDCompressionLevel(3).
 		WithBlockSize(8 * 1024).
 		WithValueThreshold(128 * 1024).
+		WithValueLogFileSize(64 * 1024 * 1024).
+		WithBlockCacheSize(16 * 1024 * 1024).
+		WithMemTableSize(16 * 1024 * 1024).
 		WithLogger(l)
 
 	engine, err := badgerengine.NewEngine(opts)

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -9,8 +9,9 @@ import (
 
 // GoWithRecovery wraps goroutine startup call with force recovery.
 // it will dump current goroutine stack into log if catch any recover result.
-//   exec:      execute logic function.
-//   recoverFn: handler will be called after recover and before dump stack, passing `nil` means noop.
+//
+//	exec:      execute logic function.
+//	recoverFn: handler will be called after recover and before dump stack, passing `nil` means noop.
 func GoWithRecovery(exec func(), recoverFn func(r interface{})) {
 	defer func() {
 		r := recover()

--- a/utils/testutil/util.go
+++ b/utils/testutil/util.go
@@ -25,10 +25,15 @@ import (
 )
 
 func NewGenjiDB(t *testing.T, storagePath string) *genji.DB {
+	badger.DefaultIteratorOptions.PrefetchValues = false
+
 	opts := badger.DefaultOptions(storagePath).
 		WithZSTDCompressionLevel(3).
 		WithBlockSize(8 * 1024).
-		WithValueThreshold(128 * 1024)
+		WithValueThreshold(128 * 1024).
+		WithValueLogFileSize(64 * 1024 * 1024).
+		WithBlockCacheSize(16 * 1024 * 1024).
+		WithMemTableSize(16 * 1024 * 1024)
 
 	engine, err := badgerengine.NewEngine(opts)
 	require.NoError(t, err)
@@ -38,10 +43,15 @@ func NewGenjiDB(t *testing.T, storagePath string) *genji.DB {
 }
 
 func NewBadgerDB(t *testing.T, storagePath string) *badger.DB {
+	badger.DefaultIteratorOptions.PrefetchValues = false
+
 	opts := badger.DefaultOptions(storagePath).
 		WithZSTDCompressionLevel(3).
 		WithBlockSize(8 * 1024).
-		WithValueThreshold(128 * 1024)
+		WithValueThreshold(128 * 1024).
+		WithValueLogFileSize(64 * 1024 * 1024).
+		WithBlockCacheSize(16 * 1024 * 1024).
+		WithMemTableSize(16 * 1024 * 1024)
 
 	engine, err := badgerengine.NewEngine(opts)
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

ngm occupies much memory when it collects lots of conprof data. It is mainly caused by retention of conprof. When executing `DELETE FROM conprof_table WHERE ts <= ?`, genji does an index scan through iterator, which acts prefetch due to the default option. The prefetch loads conprof data to memory through mmap but never read them. We benefit little from prefetch, but it does cause memory usage to increase.

### What is changed and how it works?

* Disable prefetch.
* Tweak options of badger.