### PR TITLE
[release-8.5] build: bump Go to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/ng-monitoring
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #335

### What is changed and how it works?
- bump the Go version in `go.mod` from `1.25.7` to `1.25.8`
- keep this PR limited to the Go version upgrade only
- intentionally target `release-8.5` only

### Verification
- `go test ./...`