### PR TITLE
ci: declare workflow-level `contents: read` on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - 'release-**'
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just runs `go build`/`go test` on PR and push. No GitHub API writes, so `contents: read` at the workflow level is the right ceiling for the default `GITHUB_TOKEN`.

Same per-workflow least-privilege pattern that became standard after CVE-2025-30066 (`tj-actions/changed-files` exfiltrated unspoken token scopes from caller workflow logs).

YAML validated locally.