### PR TITLE
[release-8.5] build: bump Go to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/ng-monitoring
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #339

### What is changed and how it works?
- bump the Go version in `go.mod` from `1.25.8` to `1.25.10`
- keep this PR limited to the Go version upgrade only
- intentionally target `release-8.5` only

### Verification
- `go test ./component/conprof/store -count=1 -json`
- `go test ./...` still shows an intermittent failure in `github.com/pingcap/ng-monitoring/component/conprof/store` in this environment