### PR TITLE
feat: unify log rotation settings across logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,24 @@ $ cat config/config.toml.example
   # - docdb.log
   # - tsdb.log
   #
+  # Example:
+  #   path = "/var/log/ng-monitoring"
+  #   => /var/log/ng-monitoring/ng.log
+  #   => /var/log/ng-monitoring/service.log
+  #   => /var/log/ng-monitoring/docdb.log
+  #   => /var/log/ng-monitoring/tsdb.log
+  #
   # When unset:
   # - ng.log is written to stdout
   # - service.log is written to stdout
   # - docdb.log is written to ./docdb-log/docdb.log
   # - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
+  #
+  # Example when unset and storage.path = "data":
+  # - ng.log => stdout
+  # - service.log => stdout
+  # - docdb.log => ./docdb-log/docdb.log
+  # - tsdb.log => data/tsdb-log/tsdb.log
   path = "log"
   
   # Log level: DEBUG, INFO, WARN, ERROR

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ $ cat config/config.toml.example
   
   # Log level: DEBUG, INFO, WARN, ERROR
   level = "INFO"
+
+  # Max size per log file in MB before rotation
+  max-size = 300
+
+  # Max age in days for rotated logs. 0 means never delete by age
+  max-days = 0
+
+  # Maximum number of rotated log files to keep
+  max-backups = 10
   
   [pd]
   # Addresses of PD instances within the TiDB cluster. Multiple addresses are separated by commas, e.g. ["10.0.0.1:2379","10.0.0.2:2379"]

--- a/README.md
+++ b/README.md
@@ -38,27 +38,27 @@ $ cat config/config.toml.example
   # When set, the following log files are written under this directory:
   # - ng.log
   # - service.log
-  # - docdb.log
   # - tsdb.log
+  # - docdb.log (only when docdb-backend is not "sqlite")
   #
   # Example:
   #   path = "/var/log/ng-monitoring"
   #   => /var/log/ng-monitoring/ng.log
   #   => /var/log/ng-monitoring/service.log
-  #   => /var/log/ng-monitoring/docdb.log
   #   => /var/log/ng-monitoring/tsdb.log
+  #   => /var/log/ng-monitoring/docdb.log (only when docdb-backend is not "sqlite")
   #
   # When unset:
   # - ng.log is written to stdout
   # - service.log is written to stdout
-  # - docdb.log is written to ./docdb-log/docdb.log
   # - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
+  # - docdb.log is written to ./docdb-log/docdb.log (only when docdb-backend is not "sqlite")
   #
-  # Example when unset and storage.path = "data":
+  # Example when unset, storage.path = "data", and docdb-backend = "sqlite":
   # - ng.log => stdout
   # - service.log => stdout
-  # - docdb.log => ./docdb-log/docdb.log
   # - tsdb.log => data/tsdb-log/tsdb.log
+  # - docdb.log => not generated
   path = "log"
   
   # Log level: DEBUG, INFO, WARN, ERROR

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ $ cat config/config.toml.example
   
   [log]
   # Log path
+  # When set, the following log files are written under this directory:
+  # - ng.log
+  # - service.log
+  # - docdb.log
+  # - tsdb.log
+  #
+  # When unset:
+  # - ng.log is written to stdout
+  # - service.log is written to stdout
+  # - docdb.log is written to ./docdb-log/docdb.log
+  # - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
   path = "log"
   
   # Log level: DEBUG, INFO, WARN, ERROR

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,10 @@ var defaultConfig = Config{
 		Endpoints: []string{"127.0.0.1:2379"},
 	},
 	Log: Log{
-		Path:  "", // default output is stdout
-		Level: "INFO",
+		Path:       "", // default output is stdout
+		Level:      "INFO",
+		MaxSize:    300,
+		MaxBackups: 10,
 	},
 	Storage: Storage{
 		Path:         "data",
@@ -298,8 +300,11 @@ func (s *Storage) valid() error {
 }
 
 type Log struct {
-	Path  string `toml:"path" json:"path"`
-	Level string `toml:"level" json:"level"`
+	Path       string `toml:"path" json:"path"`
+	Level      string `toml:"level" json:"level"`
+	MaxSize    int    `toml:"max-size" json:"max_size"`
+	MaxDays    int    `toml:"max-days" json:"max_days"`
+	MaxBackups int    `toml:"max-backups" json:"max_backups"`
 }
 
 const (
@@ -319,6 +324,15 @@ func (l *Log) valid() error {
 	default:
 		return fmt.Errorf("log level should be %s, %s, %s or %s", LevelDebug, LevelInfo, LevelWarn, LevelError)
 	}
+	if l.MaxSize < 0 {
+		return fmt.Errorf("log max-size should be greater than or equal to 0")
+	}
+	if l.MaxDays < 0 {
+		return fmt.Errorf("log max-days should be greater than or equal to 0")
+	}
+	if l.MaxBackups < 0 {
+		return fmt.Errorf("log max-backups should be greater than or equal to 0")
+	}
 
 	return nil
 }
@@ -326,7 +340,7 @@ func (l *Log) valid() error {
 func (l *Log) InitDefaultLogger() {
 	cfg := &log.Config{Level: strings.ToLower(l.Level)}
 	if l.Path != "" {
-		cfg.File = log.FileLogConfig{Filename: path.Join(l.Path, "ng.log")}
+		cfg.File = l.FileLogConfig(path.Join(l.Path, "ng.log"))
 	}
 
 	logger, p, err := log.InitLogger(cfg)
@@ -334,6 +348,15 @@ func (l *Log) InitDefaultLogger() {
 		stdlog.Fatalf("Failed to init logger, err: %v", err)
 	}
 	log.ReplaceGlobals(logger, p)
+}
+
+func (l *Log) FileLogConfig(filename string) log.FileLogConfig {
+	return log.FileLogConfig{
+		Filename:   filename,
+		MaxSize:    l.MaxSize,
+		MaxDays:    l.MaxDays,
+		MaxBackups: l.MaxBackups,
+	}
 }
 
 func ReloadRoutine(ctx context.Context, configPath string) {

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -10,27 +10,27 @@ advertise-address = "0.0.0.0:12020"
 # When set, the following log files are written under this directory:
 # - ng.log
 # - service.log
-# - docdb.log
 # - tsdb.log
+# - docdb.log (only when docdb-backend is not "sqlite")
 #
 # Example:
 #   path = "/var/log/ng-monitoring"
 #   => /var/log/ng-monitoring/ng.log
 #   => /var/log/ng-monitoring/service.log
-#   => /var/log/ng-monitoring/docdb.log
 #   => /var/log/ng-monitoring/tsdb.log
+#   => /var/log/ng-monitoring/docdb.log (only when docdb-backend is not "sqlite")
 #
 # When unset:
 # - ng.log is written to stdout
 # - service.log is written to stdout
-# - docdb.log is written to ./docdb-log/docdb.log
 # - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
+# - docdb.log is written to ./docdb-log/docdb.log (only when docdb-backend is not "sqlite")
 #
-# Example when unset and storage.path = "data":
+# Example when unset, storage.path = "data", and docdb-backend = "sqlite":
 # - ng.log => stdout
 # - service.log => stdout
-# - docdb.log => ./docdb-log/docdb.log
 # - tsdb.log => data/tsdb-log/tsdb.log
+# - docdb.log => not generated
 path = "log"
 
 # Log level: DEBUG, INFO, WARN, ERROR

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -13,11 +13,24 @@ advertise-address = "0.0.0.0:12020"
 # - docdb.log
 # - tsdb.log
 #
+# Example:
+#   path = "/var/log/ng-monitoring"
+#   => /var/log/ng-monitoring/ng.log
+#   => /var/log/ng-monitoring/service.log
+#   => /var/log/ng-monitoring/docdb.log
+#   => /var/log/ng-monitoring/tsdb.log
+#
 # When unset:
 # - ng.log is written to stdout
 # - service.log is written to stdout
 # - docdb.log is written to ./docdb-log/docdb.log
 # - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
+#
+# Example when unset and storage.path = "data":
+# - ng.log => stdout
+# - service.log => stdout
+# - docdb.log => ./docdb-log/docdb.log
+# - tsdb.log => data/tsdb-log/tsdb.log
 path = "log"
 
 # Log level: DEBUG, INFO, WARN, ERROR

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -12,6 +12,15 @@ path = "log"
 # Log level: DEBUG, INFO, WARN, ERROR
 level = "INFO"
 
+# Max size per log file in MB before rotation
+max-size = 300
+
+# Max age in days for rotated logs. 0 means never delete by age
+max-days = 0
+
+# Maximum number of rotated log files to keep
+max-backups = 10
+
 [pd]
 # Addresses of PD instances within the TiDB cluster. Multiple addresses are separated by commas, e.g. ["10.0.0.1:2379","10.0.0.2:2379"]
 endpoints = ["0.0.0.0:2379"]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -7,6 +7,17 @@ advertise-address = "0.0.0.0:12020"
 
 [log]
 # Log path
+# When set, the following log files are written under this directory:
+# - ng.log
+# - service.log
+# - docdb.log
+# - tsdb.log
+#
+# When unset:
+# - ng.log is written to stdout
+# - service.log is written to stdout
+# - docdb.log is written to ./docdb-log/docdb.log
+# - tsdb.log is written to <storage.path>/tsdb-log/tsdb.log
 path = "log"
 
 # Log level: DEBUG, INFO, WARN, ERROR

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, config.Load(configFile))
 	require.Equal(t, config.Address, "0.0.0.0:12020")
 	require.Equal(t, config.PD, PD{Endpoints: []string{"0.0.0.0:2379"}})
-	require.Equal(t, config.Log, Log{Path: "log", Level: "INFO"})
+	require.Equal(t, config.Log, Log{Path: "log", Level: "INFO", MaxSize: 300, MaxBackups: 10})
 	require.Equal(t, config.Storage, Storage{Path: "data", DocDBBackend: "sqlite", MetaRetentionSecs: 0})
 }
 
@@ -85,6 +85,8 @@ key-path = "ngm.key"`
 	require.Equal(t, "10.0.1.8:12020", cfg.AdvertiseAddress)
 	require.Equal(t, "log", cfg.Log.Path)
 	require.Equal(t, "INFO", cfg.Log.Level)
+	require.Equal(t, 300, cfg.Log.MaxSize)
+	require.Equal(t, 10, cfg.Log.MaxBackups)
 	require.Len(t, cfg.PD.Endpoints, 1)
 	require.Equal(t, "10.0.1.8:2379", cfg.PD.Endpoints[0])
 	require.Equal(t, "data", cfg.Storage.Path)
@@ -120,6 +122,8 @@ path = "data1"`
 	require.Equal(t, "10.0.1.8:12020", globalCfg.AdvertiseAddress)
 	require.Equal(t, "log", globalCfg.Log.Path)
 	require.Equal(t, "INFO", globalCfg.Log.Level)
+	require.Equal(t, 300, globalCfg.Log.MaxSize)
+	require.Equal(t, 10, globalCfg.Log.MaxBackups)
 	require.Len(t, globalCfg.PD.Endpoints, 2)
 	require.Equal(t, "10.0.1.8:2378", globalCfg.PD.Endpoints[0])
 	require.Equal(t, "10.0.1.9:2379", globalCfg.PD.Endpoints[1])
@@ -138,6 +142,8 @@ path = "data1"`
 	require.Equal(t, "10.0.1.8:12020", globalCfg.AdvertiseAddress)
 	require.Equal(t, "log", globalCfg.Log.Path)
 	require.Equal(t, "INFO", globalCfg.Log.Level)
+	require.Equal(t, 300, globalCfg.Log.MaxSize)
+	require.Equal(t, 10, globalCfg.Log.MaxBackups)
 	require.Len(t, globalCfg.PD.Endpoints, 2)
 	require.Equal(t, "10.0.1.8:2378", globalCfg.PD.Endpoints[0])
 	require.Equal(t, "10.0.1.9:2379", globalCfg.PD.Endpoints[1])
@@ -157,6 +163,12 @@ func TestConfigValid(t *testing.T) {
 	require.Equal(t, logCfg.valid().Error(), "unexpected empty log level")
 	logCfg = Log{Path: "log", Level: "unknow"}
 	require.Equal(t, logCfg.valid().Error(), "log level should be DEBUG, INFO, WARN or ERROR")
+	logCfg = Log{Path: "log", Level: "INFO", MaxSize: -1}
+	require.Equal(t, logCfg.valid().Error(), "log max-size should be greater than or equal to 0")
+	logCfg = Log{Path: "log", Level: "INFO", MaxDays: -1}
+	require.Equal(t, logCfg.valid().Error(), "log max-days should be greater than or equal to 0")
+	logCfg = Log{Path: "log", Level: "INFO", MaxBackups: -1}
+	require.Equal(t, logCfg.valid().Error(), "log max-backups should be greater than or equal to 0")
 	logCfg = Log{Path: "log", Level: "INFO"}
 	require.Equal(t, logCfg.valid(), nil)
 	logCfg.InitDefaultLogger()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, config.Load(configFile))
 	require.Equal(t, config.Address, "0.0.0.0:12020")
 	require.Equal(t, config.PD, PD{Endpoints: []string{"0.0.0.0:2379"}})
-	require.Equal(t, config.Log, Log{Path: "log", Level: "INFO", MaxSize: 300, MaxBackups: 10})
+	require.Equal(t, config.Log, Log{Path: "log", Level: "INFO", MaxSize: 300, MaxDays: 0, MaxBackups: 10})
 	require.Equal(t, config.Storage, Storage{Path: "data", DocDBBackend: "sqlite", MetaRetentionSecs: 0})
 }
 
@@ -86,6 +86,7 @@ key-path = "ngm.key"`
 	require.Equal(t, "log", cfg.Log.Path)
 	require.Equal(t, "INFO", cfg.Log.Level)
 	require.Equal(t, 300, cfg.Log.MaxSize)
+	require.Equal(t, 0, cfg.Log.MaxDays)
 	require.Equal(t, 10, cfg.Log.MaxBackups)
 	require.Len(t, cfg.PD.Endpoints, 1)
 	require.Equal(t, "10.0.1.8:2379", cfg.PD.Endpoints[0])
@@ -123,6 +124,7 @@ path = "data1"`
 	require.Equal(t, "log", globalCfg.Log.Path)
 	require.Equal(t, "INFO", globalCfg.Log.Level)
 	require.Equal(t, 300, globalCfg.Log.MaxSize)
+	require.Equal(t, 0, globalCfg.Log.MaxDays)
 	require.Equal(t, 10, globalCfg.Log.MaxBackups)
 	require.Len(t, globalCfg.PD.Endpoints, 2)
 	require.Equal(t, "10.0.1.8:2378", globalCfg.PD.Endpoints[0])
@@ -143,6 +145,7 @@ path = "data1"`
 	require.Equal(t, "log", globalCfg.Log.Path)
 	require.Equal(t, "INFO", globalCfg.Log.Level)
 	require.Equal(t, 300, globalCfg.Log.MaxSize)
+	require.Equal(t, 0, globalCfg.Log.MaxDays)
 	require.Equal(t, 10, globalCfg.Log.MaxBackups)
 	require.Len(t, globalCfg.PD.Endpoints, 2)
 	require.Equal(t, "10.0.1.8:2378", globalCfg.PD.Endpoints[0])

--- a/database/docdb/genji.go
+++ b/database/docdb/genji.go
@@ -23,10 +23,11 @@ import (
 )
 
 type GenjiConfig struct {
-	Path         string
-	LogPath      string
-	LogLevel     string
-	BadgerConfig BadgerConfig
+	Path          string
+	LogPath       string
+	LogLevel      string
+	LogFileConfig log.FileLogConfig
+	BadgerConfig  BadgerConfig
 }
 
 type BadgerConfig struct {
@@ -62,7 +63,7 @@ type genjiDB struct {
 func NewGenjiDB(ctx context.Context, cfg *GenjiConfig) (DocDB, error) {
 	badger.DefaultIteratorOptions.PrefetchValues = false
 	dataPath := path.Join(cfg.Path, "docdb")
-	l, _ := initLogger(cfg.LogPath, cfg.LogLevel)
+	l, _ := initLogger(cfg.LogPath, cfg.LogLevel, cfg.LogFileConfig)
 	var opts badger.Options
 	if cfg.BadgerConfig.LSMOnly {
 		opts = badger.LSMOnlyOptions(dataPath)

--- a/database/docdb/genji.go
+++ b/database/docdb/genji.go
@@ -3,7 +3,9 @@ package docdb
 import (
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
+	"io"
 	"path"
 	"runtime"
 	"strconv"
@@ -13,7 +15,7 @@ import (
 	"github.com/genjidb/genji"
 	"github.com/genjidb/genji/document"
 	"github.com/genjidb/genji/engine/badgerengine"
-	"github.com/genjidb/genji/errors"
+	genjierrors "github.com/genjidb/genji/errors"
 	"github.com/genjidb/genji/types"
 	"github.com/pingcap/log"
 	"github.com/pingcap/ng-monitoring/component/conprof/meta"
@@ -56,8 +58,9 @@ type BadgerConfig struct {
 }
 
 type genjiDB struct {
-	db      *genji.DB
-	closeCh chan struct{}
+	db        *genji.DB
+	closeCh   chan struct{}
+	logCloser io.Closer
 }
 
 func NewGenjiDB(ctx context.Context, cfg *GenjiConfig) (DocDB, error) {
@@ -99,7 +102,7 @@ func NewGenjiDB(ctx context.Context, cfg *GenjiConfig) (DocDB, error) {
 	if err != nil {
 		return nil, err
 	}
-	d := &genjiDB{closeCh: make(chan struct{})}
+	d := &genjiDB{closeCh: make(chan struct{}), logCloser: l}
 	go utils.GoWithRecovery(func() {
 		doGCLoop(engine.DB, d.closeCh)
 	}, nil)
@@ -138,7 +141,7 @@ func (d *genjiDB) tryInitTables() error {
 
 func (d *genjiDB) Close() error {
 	close(d.closeCh)
-	return d.db.Close()
+	return stderrors.Join(d.db.Close(), closeLogCloser(d.logCloser))
 }
 
 func (d *genjiDB) SaveConfig(ctx context.Context, cfg map[string]string) error {
@@ -190,7 +193,7 @@ func (d *genjiDB) WriteSQLMeta(ctx context.Context, meta *tipb.SQLMeta) error {
 func (d *genjiDB) QuerySQLMeta(ctx context.Context, digest string) (string, error) {
 	r, err := d.db.WithContext(ctx).QueryDocument("SELECT sql_text FROM sql_digest WHERE digest = ?", digest)
 	if err != nil {
-		if err == errors.ErrDocumentNotFound {
+		if err == genjierrors.ErrDocumentNotFound {
 			return "", nil
 		}
 		return "", err
@@ -209,7 +212,7 @@ func (d *genjiDB) DeleteSQLMetaBeforeTs(ctx context.Context, ts int64) error {
 func (d *genjiDB) QueryPlanMeta(ctx context.Context, digest string) (string, string, error) {
 	r, err := d.db.WithContext(ctx).QueryDocument("SELECT plan_text, encoded_plan FROM plan_digest WHERE digest = ?", digest)
 	if err != nil {
-		if err == errors.ErrDocumentNotFound {
+		if err == genjierrors.ErrDocumentNotFound {
 			return "", "", nil
 		}
 		return "", "", err
@@ -219,6 +222,13 @@ func (d *genjiDB) QueryPlanMeta(ctx context.Context, digest string) (string, str
 		return "", "", err
 	}
 	return text, encodedPlan, nil
+}
+
+func closeLogCloser(closer io.Closer) error {
+	if closer == nil {
+		return nil
+	}
+	return closer.Close()
 }
 
 func (d *genjiDB) WritePlanMeta(ctx context.Context, meta *tipb.PlanMeta) error {

--- a/database/docdb/genji_logger.go
+++ b/database/docdb/genji_logger.go
@@ -1,11 +1,13 @@
 package docdb
 
 import (
+	"io"
 	stdlog "log"
 	"os"
 	"path"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/ng-monitoring/utils/logutil"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +32,7 @@ type logger struct {
 	level loggingLevel
 }
 
-func initLogger(logPath, logLevel string) (*logger, error) {
+func initLogger(logPath, logLevel string, fileCfg log.FileLogConfig) (*logger, error) {
 	var err error
 	var logDir string
 	if logPath != "" {
@@ -43,7 +45,8 @@ func initLogger(logPath, logLevel string) (*logger, error) {
 		}
 	}
 	logFileName := path.Join(logDir, "docdb.log")
-	logFile, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	fileCfg.Filename = logFileName
+	logFile, err := logutil.NewRotateWriter(fileCfg)
 	if err != nil {
 		// Need to log via the default logger due to `l` is not initialized.
 		log.Warn("Failed to init logger", zap.String("filename", logFileName))
@@ -62,7 +65,7 @@ func initLogger(logPath, logLevel string) (*logger, error) {
 	default:
 		log.Fatal("Unsupported log level", zap.String("level", logLevel))
 	}
-	return &logger{Logger: stdlog.New(logFile, "badger ", stdlog.LstdFlags), level: level}, nil
+	return &logger{Logger: stdlog.New(io.Writer(logFile), "badger ", stdlog.LstdFlags), level: level}, nil
 }
 
 func (l *logger) Errorf(f string, v ...interface{}) {

--- a/database/docdb/genji_logger.go
+++ b/database/docdb/genji_logger.go
@@ -29,7 +29,8 @@ const (
 
 type logger struct {
 	*stdlog.Logger
-	level loggingLevel
+	level  loggingLevel
+	closer io.Closer
 }
 
 func initLogger(logPath, logLevel string, fileCfg log.FileLogConfig) (*logger, error) {
@@ -65,7 +66,11 @@ func initLogger(logPath, logLevel string, fileCfg log.FileLogConfig) (*logger, e
 	default:
 		log.Fatal("Unsupported log level", zap.String("level", logLevel))
 	}
-	return &logger{Logger: stdlog.New(io.Writer(logFile), "badger ", stdlog.LstdFlags), level: level}, nil
+	return &logger{
+		Logger: stdlog.New(io.Writer(logFile), "badger ", stdlog.LstdFlags),
+		level:  level,
+		closer: logFile,
+	}, nil
 }
 
 func (l *logger) Errorf(f string, v ...interface{}) {
@@ -90,4 +95,11 @@ func (l *logger) Debugf(f string, v ...interface{}) {
 	if l.level <= DEBUG {
 		l.Printf("DEBUG: "+f, v...)
 	}
+}
+
+func (l *logger) Close() error {
+	if l == nil || l.closer == nil {
+		return nil
+	}
+	return l.closer.Close()
 }

--- a/database/timeseries/syscall_linux.go
+++ b/database/timeseries/syscall_linux.go
@@ -4,6 +4,10 @@ import (
 	"syscall"
 )
 
+func dup(fd int) (int, error) {
+	return syscall.Dup(fd)
+}
+
 func dup2(oldfd int, newfd int) error {
 	return syscall.Dup3(oldfd, newfd, 0)
 }

--- a/database/timeseries/syscall_not_linux_unix.go
+++ b/database/timeseries/syscall_not_linux_unix.go
@@ -7,6 +7,10 @@ import (
 	"syscall"
 )
 
+func dup(fd int) (int, error) {
+	return syscall.Dup(fd)
+}
+
 func dup2(oldfd int, newfd int) error {
 	return syscall.Dup2(oldfd, newfd)
 }

--- a/database/timeseries/vm.go
+++ b/database/timeseries/vm.go
@@ -1,11 +1,13 @@
 package timeseries
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/pingcap/ng-monitoring/config"
@@ -22,7 +24,17 @@ import (
 	"github.com/pingcap/log"
 )
 
-var tsdbLogForwarderStarted bool
+var (
+	tsdbLogForwarderMu sync.Mutex
+	tsdbLogForwarder   *stderrForwarder
+	originalStderr     *os.File
+)
+
+type stderrForwarder struct {
+	reader   *os.File
+	sink     io.WriteCloser
+	copyDone chan error
+}
 
 func Init(cfg *config.Config) {
 	if err := initLogger(cfg); err != nil {
@@ -80,6 +92,7 @@ func Stop() {
 	fs.MustStopDirRemover()
 
 	logger.Infof("the VictoriaMetrics has been stopped in %.3f seconds", time.Since(startTime).Seconds())
+	stopTSDBLogForwarder()
 }
 
 func initLogger(cfg *config.Config) error {
@@ -100,30 +113,124 @@ func initLogger(cfg *config.Config) error {
 
 	// VictoriaMetrics only supports stdout or stderr as log output.
 	// Redirect stderr to a pipe and forward it to a rotating file writer.
-	if !tsdbLogForwarderStarted {
-		logFileName := path.Join(logDir, "tsdb.log")
-		file, err := logutil.NewRotateWriter(cfg.Log.FileLogConfig(logFileName))
-		if err != nil {
-			return err
-		}
-		reader, writer, err := os.Pipe()
-		if err != nil {
-			return err
-		}
-		go func() {
-			_, _ = io.Copy(file, reader)
-		}()
-		if err = dup2(int(writer.Fd()), int(os.Stderr.Fd())); err != nil {
-			_ = reader.Close()
-			_ = writer.Close()
-			return err
-		}
-		_ = writer.Close()
-		tsdbLogForwarderStarted = true
+	logFileName := path.Join(logDir, "tsdb.log")
+	if err := replaceTSDBLogForwarder(cfg.Log.FileLogConfig(logFileName)); err != nil {
+		return err
 	}
 	logger.Init()
 
 	return nil
+}
+
+func replaceTSDBLogForwarder(fileCfg log.FileLogConfig) error {
+	tsdbLogForwarderMu.Lock()
+	defer tsdbLogForwarderMu.Unlock()
+
+	if err := ensureOriginalStderrLocked(); err != nil {
+		return err
+	}
+	stopTSDBLogForwarderLocked()
+
+	sink, err := logutil.NewRotateWriter(fileCfg)
+	if err != nil {
+		return err
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		_ = sink.Close()
+		return err
+	}
+	if err = dup2(int(writer.Fd()), int(os.Stderr.Fd())); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		_ = sink.Close()
+		return err
+	}
+	_ = writer.Close()
+
+	forwarder := &stderrForwarder{
+		reader:   reader,
+		sink:     sink,
+		copyDone: make(chan error, 1),
+	}
+	go forwarder.forward(originalStderr)
+	tsdbLogForwarder = forwarder
+	return nil
+}
+
+func stopTSDBLogForwarder() {
+	tsdbLogForwarderMu.Lock()
+	defer tsdbLogForwarderMu.Unlock()
+	stopTSDBLogForwarderLocked()
+}
+
+func stopTSDBLogForwarderLocked() {
+	if tsdbLogForwarder == nil {
+		return
+	}
+
+	forwarder := tsdbLogForwarder
+	tsdbLogForwarder = nil
+
+	restoreErr := dup2(int(originalStderr.Fd()), int(os.Stderr.Fd()))
+	if restoreErr != nil {
+		log.Warn("failed to restore stderr after tsdb logging", zap.Error(restoreErr))
+		_ = forwarder.reader.Close()
+	}
+
+	if copyErr := <-forwarder.copyDone; copyErr != nil {
+		log.Warn("tsdb log forwarder exited unexpectedly", zap.Error(copyErr))
+	}
+	if err := forwarder.reader.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		log.Warn("failed to close tsdb log reader", zap.Error(err))
+	}
+	if err := forwarder.sink.Close(); err != nil {
+		log.Warn("failed to close tsdb log writer", zap.Error(err))
+	}
+}
+
+func ensureOriginalStderrLocked() error {
+	if originalStderr != nil {
+		return nil
+	}
+	fd, err := dup(int(os.Stderr.Fd()))
+	if err != nil {
+		return err
+	}
+	originalStderr = os.NewFile(uintptr(fd), "original-stderr")
+	return nil
+}
+
+func (f *stderrForwarder) forward(fallback io.Writer) {
+	f.copyDone <- copyWithFallback(f.reader, f.sink, fallback)
+}
+
+func copyWithFallback(reader io.Reader, primary io.Writer, fallback io.Writer) error {
+	buf := make([]byte, 32*1024)
+	writer := primary
+	switchedToFallback := false
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			if _, writeErr := writer.Write(buf[:n]); writeErr != nil {
+				if !switchedToFallback && fallback != nil {
+					switchedToFallback = true
+					writer = fallback
+					_, _ = fmt.Fprintf(fallback, "tsdb log rotation writer failed, fallback to stderr: %v\n", writeErr)
+					_, _ = writer.Write(buf[:n])
+				} else {
+					return writeErr
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
 }
 
 func initDataDir(dataPath string) {

--- a/database/timeseries/vm.go
+++ b/database/timeseries/vm.go
@@ -3,11 +3,13 @@ package timeseries
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"time"
 
 	"github.com/pingcap/ng-monitoring/config"
+	"github.com/pingcap/ng-monitoring/utils/logutil"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vminsert"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect"
@@ -15,9 +17,12 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"github.com/pingcap/log"
 	"go.uber.org/zap"
+
+	"github.com/pingcap/log"
 )
+
+var tsdbLogForwarderStarted bool
 
 func Init(cfg *config.Config) {
 	if err := initLogger(cfg); err != nil {
@@ -94,14 +99,27 @@ func initLogger(cfg *config.Config) error {
 	}
 
 	// VictoriaMetrics only supports stdout or stderr as log output.
-	// To output the log to the specified file, redirect stderr to that file.
-	logFileName := path.Join(logDir, "tsdb.log")
-	file, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		return err
-	}
-	if err = dup2(int(file.Fd()), int(os.Stderr.Fd())); err != nil {
-		return err
+	// Redirect stderr to a pipe and forward it to a rotating file writer.
+	if !tsdbLogForwarderStarted {
+		logFileName := path.Join(logDir, "tsdb.log")
+		file, err := logutil.NewRotateWriter(cfg.Log.FileLogConfig(logFileName))
+		if err != nil {
+			return err
+		}
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		go func() {
+			_, _ = io.Copy(file, reader)
+		}()
+		if err = dup2(int(writer.Fd()), int(os.Stderr.Fd())); err != nil {
+			_ = reader.Close()
+			_ = writer.Close()
+			return err
+		}
+		_ = writer.Close()
+		tsdbLogForwarderStarted = true
 	}
 	logger.Init()
 

--- a/database/timeseries/vm.go
+++ b/database/timeseries/vm.go
@@ -126,10 +126,16 @@ func replaceTSDBLogForwarder(fileCfg log.FileLogConfig) error {
 	tsdbLogForwarderMu.Lock()
 	defer tsdbLogForwarderMu.Unlock()
 
+	stopTSDBLogForwarderLocked()
 	if err := ensureOriginalStderrLocked(); err != nil {
 		return err
 	}
-	stopTSDBLogForwarderLocked()
+	keepOriginalStderr := false
+	defer func() {
+		if !keepOriginalStderr {
+			closeOriginalStderrLocked()
+		}
+	}()
 
 	sink, err := logutil.NewRotateWriter(fileCfg)
 	if err != nil {
@@ -155,6 +161,7 @@ func replaceTSDBLogForwarder(fileCfg log.FileLogConfig) error {
 	}
 	go forwarder.forward(originalStderr)
 	tsdbLogForwarder = forwarder
+	keepOriginalStderr = true
 	return nil
 }
 
@@ -166,16 +173,21 @@ func stopTSDBLogForwarder() {
 
 func stopTSDBLogForwarderLocked() {
 	if tsdbLogForwarder == nil {
+		closeOriginalStderrLocked()
 		return
 	}
 
 	forwarder := tsdbLogForwarder
 	tsdbLogForwarder = nil
 
-	restoreErr := dup2(int(originalStderr.Fd()), int(os.Stderr.Fd()))
-	if restoreErr != nil {
-		log.Warn("failed to restore stderr after tsdb logging", zap.Error(restoreErr))
+	if originalStderr == nil {
 		_ = forwarder.reader.Close()
+	} else {
+		restoreErr := dup2(int(originalStderr.Fd()), int(os.Stderr.Fd()))
+		if restoreErr != nil {
+			log.Warn("failed to restore stderr after tsdb logging", zap.Error(restoreErr))
+			_ = forwarder.reader.Close()
+		}
 	}
 
 	if copyErr := <-forwarder.copyDone; copyErr != nil {
@@ -187,6 +199,7 @@ func stopTSDBLogForwarderLocked() {
 	if err := forwarder.sink.Close(); err != nil {
 		log.Warn("failed to close tsdb log writer", zap.Error(err))
 	}
+	closeOriginalStderrLocked()
 }
 
 func ensureOriginalStderrLocked() error {
@@ -199,6 +212,16 @@ func ensureOriginalStderrLocked() error {
 	}
 	originalStderr = os.NewFile(uintptr(fd), "original-stderr")
 	return nil
+}
+
+func closeOriginalStderrLocked() {
+	if originalStderr == nil {
+		return
+	}
+	if err := originalStderr.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		log.Warn("failed to close saved stderr", zap.Error(err))
+	}
+	originalStderr = nil
 }
 
 func (f *stderrForwarder) forward(fallback io.Writer) {

--- a/main.go
+++ b/main.go
@@ -84,10 +84,11 @@ func main() {
 		docDB, err = docdb.NewSQLiteDB(cfg.Storage.Path, cfg.Storage.SQLiteUseWAL)
 	default:
 		docDB, err = docdb.NewGenjiDB(context.Background(), &docdb.GenjiConfig{
-			Path:         cfg.Storage.Path,
-			LogPath:      cfg.Log.Path,
-			LogLevel:     cfg.Log.Level,
-			BadgerConfig: cfg.DocDB,
+			Path:          cfg.Storage.Path,
+			LogPath:       cfg.Log.Path,
+			LogLevel:      cfg.Log.Level,
+			LogFileConfig: cfg.Log.FileLogConfig(""),
+			BadgerConfig:  cfg.DocDB,
 		})
 	}
 	if err != nil {

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/pingcap/ng-monitoring/component/topsql"
 	"github.com/pingcap/ng-monitoring/config"
 	"github.com/pingcap/ng-monitoring/database/docdb"
+	"github.com/pingcap/ng-monitoring/utils/logutil"
 
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
@@ -32,16 +34,18 @@ func ServeHTTP(l *config.Log, listener net.Listener, docDB docdb.DocDB) {
 
 	var logFile *os.File
 	var err error
+	var accessLog io.Writer
 	if l.Path != "" {
 		logFileName := path.Join(l.Path, "service.log")
-		logFile, err = os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		accessLog, err = logutil.NewRotateWriter(l.FileLogConfig(logFileName))
 		if err != nil {
 			log.Fatal("Failed to open the log file", zap.String("filename", logFileName))
 		}
 	} else {
 		logFile = os.Stdout
+		accessLog = logFile
 	}
-	ng.Use(gin.LoggerWithWriter(logFile))
+	ng.Use(gin.LoggerWithWriter(accessLog))
 
 	// recovery
 	ng.Use(gin.Recovery())

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -25,8 +25,7 @@ import (
 )
 
 var (
-	httpServer    *http.Server = nil
-	httpAccessLog io.Closer
+	httpServer *http.Server = nil
 )
 
 func ServeHTTP(l *config.Log, listener net.Listener, docDB docdb.DocDB) {
@@ -42,11 +41,12 @@ func ServeHTTP(l *config.Log, listener net.Listener, docDB docdb.DocDB) {
 			log.Fatal("Failed to open the log file", zap.String("filename", logFileName))
 		}
 		accessLog = rotateWriter
-		httpAccessLog = rotateWriter
-	} else {
-		httpAccessLog = nil
+		defer func() {
+			if err := rotateWriter.Close(); err != nil {
+				log.Warn("failed to close http access log writer", zap.Error(err))
+			}
+		}()
 	}
-	defer closeHTTPAccessLog()
 	ng.Use(gin.LoggerWithWriter(accessLog))
 
 	// recovery
@@ -110,22 +110,10 @@ type Status struct {
 
 func StopHTTP() {
 	if httpServer == nil {
-		closeHTTPAccessLog()
 		return
 	}
 
 	log.Info("shutting down http server")
 	_ = httpServer.Close()
-	closeHTTPAccessLog()
 	log.Info("http server is down")
-}
-
-func closeHTTPAccessLog() {
-	if httpAccessLog == nil {
-		return
-	}
-	if err := httpAccessLog.Close(); err != nil {
-		log.Warn("failed to close http access log writer", zap.Error(err))
-	}
-	httpAccessLog = nil
 }

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -25,26 +25,28 @@ import (
 )
 
 var (
-	httpServer *http.Server = nil
+	httpServer    *http.Server = nil
+	httpAccessLog io.Closer
 )
 
 func ServeHTTP(l *config.Log, listener net.Listener, docDB docdb.DocDB) {
 	gin.SetMode(gin.ReleaseMode)
 	ng := gin.New()
 
-	var logFile *os.File
 	var err error
-	var accessLog io.Writer
+	accessLog := io.Writer(os.Stdout)
 	if l.Path != "" {
 		logFileName := path.Join(l.Path, "service.log")
-		accessLog, err = logutil.NewRotateWriter(l.FileLogConfig(logFileName))
+		rotateWriter, err := logutil.NewRotateWriter(l.FileLogConfig(logFileName))
 		if err != nil {
 			log.Fatal("Failed to open the log file", zap.String("filename", logFileName))
 		}
+		accessLog = rotateWriter
+		httpAccessLog = rotateWriter
 	} else {
-		logFile = os.Stdout
-		accessLog = logFile
+		httpAccessLog = nil
 	}
+	defer closeHTTPAccessLog()
 	ng.Use(gin.LoggerWithWriter(accessLog))
 
 	// recovery
@@ -108,10 +110,22 @@ type Status struct {
 
 func StopHTTP() {
 	if httpServer == nil {
+		closeHTTPAccessLog()
 		return
 	}
 
 	log.Info("shutting down http server")
 	_ = httpServer.Close()
+	closeHTTPAccessLog()
 	log.Info("http server is down")
+}
+
+func closeHTTPAccessLog() {
+	if httpAccessLog == nil {
+		return
+	}
+	if err := httpAccessLog.Close(); err != nil {
+		log.Warn("failed to close http access log writer", zap.Error(err))
+	}
+	httpAccessLog = nil
 }

--- a/utils/logutil/rotate.go
+++ b/utils/logutil/rotate.go
@@ -2,6 +2,7 @@ package logutil
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pingcap/log"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -15,6 +16,13 @@ func NewRotateWriter(cfg log.FileLogConfig) (*lumberjack.Logger, error) {
 	}
 	if cfg.MaxSize == 0 {
 		cfg.MaxSize = defaultMaxSizeMB
+	}
+	file, err := os.OpenFile(cfg.Filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		return nil, err
 	}
 	return &lumberjack.Logger{
 		Filename:   cfg.Filename,

--- a/utils/logutil/rotate.go
+++ b/utils/logutil/rotate.go
@@ -1,0 +1,26 @@
+package logutil
+
+import (
+	"fmt"
+
+	"github.com/pingcap/log"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const defaultMaxSizeMB = 300
+
+func NewRotateWriter(cfg log.FileLogConfig) (*lumberjack.Logger, error) {
+	if cfg.Filename == "" {
+		return nil, fmt.Errorf("unexpected empty log filename")
+	}
+	if cfg.MaxSize == 0 {
+		cfg.MaxSize = defaultMaxSizeMB
+	}
+	return &lumberjack.Logger{
+		Filename:   cfg.Filename,
+		MaxSize:    cfg.MaxSize,
+		MaxBackups: cfg.MaxBackups,
+		MaxAge:     cfg.MaxDays,
+		LocalTime:  true,
+	}, nil
+}

--- a/utils/logutil/rotate_test.go
+++ b/utils/logutil/rotate_test.go
@@ -1,0 +1,37 @@
+package logutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pingcap/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRotateWriter(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	writer, err := NewRotateWriter(log.FileLogConfig{
+		Filename:   logFile,
+		MaxSize:    10,
+		MaxDays:    7,
+		MaxBackups: 3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, logFile, writer.Filename)
+	require.Equal(t, 10, writer.MaxSize)
+	require.Equal(t, 7, writer.MaxAge)
+	require.Equal(t, 3, writer.MaxBackups)
+
+	info, err := os.Stat(logFile)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	require.NoError(t, writer.Close())
+}
+
+func TestNewRotateWriterFailsFast(t *testing.T) {
+	_, err := NewRotateWriter(log.FileLogConfig{
+		Filename: filepath.Join(t.TempDir(), "missing-dir", "test.log"),
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #347

### What is changed and how it works?
- add shared `[log]` rotation settings for `max-size`, `max-days`, and `max-backups`
- apply the same rotation policy to `ng.log`, `service.log`, `docdb.log`, and `tsdb.log`
- keep the existing log paths and log file names unchanged while adding rotate and cleanup support
- keep `ng.log` on the same lumberjack-compatible rotation naming for upgrade compatibility

### Verification
- `go test ./config/... ./utils/logutil/... ./database/docdb/... ./database/timeseries/... ./service/...`