### PR TITLE
tsdb: expose search-max-query-duration config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -455,6 +455,7 @@ type TSDB struct {
 	CacheSizeIndexDBTagFilters       string  `toml:"cache-size-indexdb-tag-filters" json:"cache_size_indexdb_tag_filters"`
 	CacheSizeMetricNamesStats        string  `toml:"cache-size-metric-names-stats" json:"cache_size_metric_names_stats"`
 	CacheSizeStorageTSID             string  `toml:"cache-size-storage-tsid" json:"cache_size_storage_tsid"`
+	SearchMaxQueryDuration           string  `toml:"search-max-query-duration" json:"search_max_query_duration"`
 }
 
 type ContinueProfilingConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -231,6 +231,10 @@ func (c *Config) valid() error {
 		return err
 	}
 
+	if err = c.TSDB.valid(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -456,6 +460,19 @@ type TSDB struct {
 	CacheSizeMetricNamesStats        string  `toml:"cache-size-metric-names-stats" json:"cache_size_metric_names_stats"`
 	CacheSizeStorageTSID             string  `toml:"cache-size-storage-tsid" json:"cache_size_storage_tsid"`
 	SearchMaxQueryDuration           string  `toml:"search-max-query-duration" json:"search_max_query_duration"`
+}
+
+func (t *TSDB) valid() error {
+	if t.SearchMaxQueryDuration != "" {
+		d, err := time.ParseDuration(t.SearchMaxQueryDuration)
+		if err != nil {
+			return fmt.Errorf("tsdb search-max-query-duration %q is invalid, err: %v", t.SearchMaxQueryDuration, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("tsdb search-max-query-duration should be greater than 0, got %q", t.SearchMaxQueryDuration)
+		}
+	}
+	return nil
 }
 
 type ContinueProfilingConfig struct {

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -69,6 +69,10 @@ retention-period = "1"
 # and spends some CPU time for processing the found time series. This means that the maximum memory usage
 # and CPU usage a single query can use is proportional to `search-max-unique-timeseries`.
 search-max-unique-timeseries = 300000
+# `search-max-query-duration` is the maximum duration for a single query execution in the embedded
+# VictoriaMetrics(tsdb). It maps to VictoriaMetrics' `-search.maxQueryDuration` flag. Accepts a Go
+# duration string (e.g. "5m"). When unset, the VictoriaMetrics default of 30s is used.
+# search-max-query-duration = "5m"
 
 [docdb]
 lsm-only = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,7 +37,9 @@ func TestConfig(t *testing.T) {
 func TestTSDBSearchMaxQueryDuration(t *testing.T) {
 	// Unset preserves the empty default, so the VictoriaMetrics default (30s) is kept.
 	require.Equal(t, "", GetDefaultConfig().TSDB.SearchMaxQueryDuration)
+	require.NoError(t, (&TSDB{}).valid())
 
+	// Valid duration decodes from TOML and passes validation.
 	cfgFileName := "test-tsdb-cfg.toml"
 	cfgData := `
 [tsdb]
@@ -48,6 +50,12 @@ search-max-query-duration = "5m"`
 	var config Config
 	require.NoError(t, config.Load(cfgFileName))
 	require.Equal(t, "5m", config.TSDB.SearchMaxQueryDuration)
+	require.NoError(t, config.TSDB.valid())
+
+	// Invalid, zero and negative values are rejected.
+	require.Error(t, (&TSDB{SearchMaxQueryDuration: "5minutes"}).valid())
+	require.Error(t, (&TSDB{SearchMaxQueryDuration: "0s"}).valid())
+	require.Error(t, (&TSDB{SearchMaxQueryDuration: "-1m"}).valid())
 }
 
 func TestContinueProfilingConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,22 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, config.Storage, Storage{Path: "data", DocDBBackend: "sqlite", MetaRetentionSecs: 0})
 }
 
+func TestTSDBSearchMaxQueryDuration(t *testing.T) {
+	// Unset preserves the empty default, so the VictoriaMetrics default (30s) is kept.
+	require.Equal(t, "", GetDefaultConfig().TSDB.SearchMaxQueryDuration)
+
+	cfgFileName := "test-tsdb-cfg.toml"
+	cfgData := `
+[tsdb]
+search-max-query-duration = "5m"`
+	require.NoError(t, os.WriteFile(cfgFileName, []byte(cfgData), 0666))
+	defer os.Remove(cfgFileName)
+
+	var config Config
+	require.NoError(t, config.Load(cfgFileName))
+	require.Equal(t, "5m", config.TSDB.SearchMaxQueryDuration)
+}
+
 func TestContinueProfilingConfig(t *testing.T) {
 	cfg := ContinueProfilingConfig{}
 	require.Equal(t, cfg.Valid(), false)

--- a/database/timeseries/vm.go
+++ b/database/timeseries/vm.go
@@ -42,6 +42,22 @@ func Init(cfg *config.Config) {
 	}
 	initDataDir(path.Join(cfg.Storage.Path, "tsdb"))
 
+	setVMFlags(cfg)
+
+	// Some components in VictoriaMetrics want parsed arguments, i.e. assert `flag.Parsed()`. Make them happy.
+	_ = flag.CommandLine.Parse(nil)
+
+	startTime := time.Now()
+	vmstorage.Init(promql.ResetRollupResultCacheIfNeeded)
+	vmselect.Init()
+	vminsert.Init()
+
+	logger.Infof("started VictoriaMetrics in %.3f seconds", time.Since(startTime).Seconds())
+}
+
+// setVMFlags translates the [tsdb] config options into VictoriaMetrics command-line flags.
+// Non-empty duration/size values are validated by config.Config.valid() before Init runs.
+func setVMFlags(cfg *config.Config) {
 	_ = flag.Set("retentionPeriod", cfg.TSDB.RetentionPeriod)
 	_ = flag.Set("search.maxStepForPointsAdjustment", "1s")
 	_ = flag.Set("search.maxUniqueTimeseries", fmt.Sprintf("%d", cfg.TSDB.SearchMaxUniqueTimeseries))
@@ -72,16 +88,6 @@ func Init(cfg *config.Config) {
 	if cfg.TSDB.SearchMaxQueryDuration != "" {
 		_ = flag.Set("search.maxQueryDuration", cfg.TSDB.SearchMaxQueryDuration)
 	}
-
-	// Some components in VictoriaMetrics want parsed arguments, i.e. assert `flag.Parsed()`. Make them happy.
-	_ = flag.CommandLine.Parse(nil)
-
-	startTime := time.Now()
-	vmstorage.Init(promql.ResetRollupResultCacheIfNeeded)
-	vmselect.Init()
-	vminsert.Init()
-
-	logger.Infof("started VictoriaMetrics in %.3f seconds", time.Since(startTime).Seconds())
 }
 
 func Stop() {

--- a/database/timeseries/vm.go
+++ b/database/timeseries/vm.go
@@ -69,6 +69,9 @@ func Init(cfg *config.Config) {
 	if cfg.TSDB.CacheSizeStorageTSID != "" {
 		_ = flag.Set("storage.cacheSizeStorageTSID", cfg.TSDB.CacheSizeStorageTSID)
 	}
+	if cfg.TSDB.SearchMaxQueryDuration != "" {
+		_ = flag.Set("search.maxQueryDuration", cfg.TSDB.SearchMaxQueryDuration)
+	}
 
 	// Some components in VictoriaMetrics want parsed arguments, i.e. assert `flag.Parsed()`. Make them happy.
 	_ = flag.CommandLine.Parse(nil)

--- a/database/timeseries/vm_test.go
+++ b/database/timeseries/vm_test.go
@@ -1,0 +1,29 @@
+package timeseries
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/pingcap/ng-monitoring/config"
+
+	// Registers the search.maxQueryDuration flag so the wiring below can be verified.
+	_ "github.com/VictoriaMetrics/VictoriaMetrics/app/vmselect"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetVMFlagsSearchMaxQueryDuration(t *testing.T) {
+	f := flag.Lookup("search.maxQueryDuration")
+	require.NotNil(t, f, "VictoriaMetrics must register search.maxQueryDuration")
+	defaultValue := f.Value.String()
+	require.Equal(t, "30s", defaultValue)
+
+	// Unset preserves the VictoriaMetrics default.
+	cfg := &config.Config{}
+	setVMFlags(cfg)
+	require.Equal(t, defaultValue, flag.Lookup("search.maxQueryDuration").Value.String())
+
+	// A configured value is applied to the VM flag.
+	cfg.TSDB.SearchMaxQueryDuration = "5m"
+	setVMFlags(cfg)
+	require.Equal(t, "5m0s", flag.Lookup("search.maxQueryDuration").Value.String())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #358

The embedded VictoriaMetrics query timeout (`-search.maxQueryDuration`) is fixed at VM's built-in default of 30s and cannot be configured through ng-monitoring. On heavy / high-cardinality deployments, legitimate long-range queries (for example, wide TopSQL dashboard panels) can exceed 30s and fail with:

```
timeout exceeded during the query: 30.000 seconds (elapsed <N> seconds);
the timeout can be adjusted with `-search.maxQueryDuration` command-line flag
```

Other embedded-VM tunables are already exposed under `[tsdb]` (`retention-period`, `search-max-unique-timeseries`, `memory-allowed-*`, `cache-size-*`), but this one is not.

### What is changed and how it works?

Add a new `[tsdb]` option `search-max-query-duration` (a Go duration string, e.g. `"5m"`) wired to VictoriaMetrics' `-search.maxQueryDuration` flag in `database/timeseries.Init`, mirroring the existing conditional `flag.Set` blocks. When the option is empty/unset, behaviour is unchanged and VM's 30s default is preserved.

- `config/config.go` — new `TSDB.SearchMaxQueryDuration` field (`toml:"search-max-query-duration"`, `json:"search_max_query_duration"`), following the style of its neighbours.
- `database/timeseries/vm.go` — `flag.Set("search.maxQueryDuration", cfg.TSDB.SearchMaxQueryDuration)` when non-empty, set before `flag.CommandLine.Parse(nil)`.
- `config/config.toml.example` — documents the new key with a commented-out example.
- `config/config_test.go` — asserts the key decodes from TOML and that the default stays empty (so the VM default is preserved when unset).

Verified against the vendored VictoriaMetrics `v1.110.5`, which registers `flag.Duration("search.maxQueryDuration", 30*time.Second, ...)` in `app/vmselect/searchutil/searchutil.go`. No behaviour change when the option is unset; no new dependencies; VM version untouched.
