### PR TITLE
topsql: support detailed IO dimensions (#355)

### DIFF
--- a/component/topsql/query/default_query.go
+++ b/component/topsql/query/default_query.go
@@ -113,6 +113,12 @@ func (dq *DefaultQuery) SummaryBy(startSecs, endSecs, windowSecs, top int, insta
 			item.NetworkBytes = append(item.NetworkBytes, v)
 		case OrderByLogicalIO:
 			item.LogicalIoBytes = append(item.LogicalIoBytes, v)
+		case OrderByLogicalRead:
+			item.LogicalReadBytes = append(item.LogicalReadBytes, v)
+		case OrderByLogicalWrite:
+			item.LogicalWriteBytes = append(item.LogicalWriteBytes, v)
+		case OrderByBlockRead:
+			item.RocksdbBlockReadCount = append(item.RocksdbBlockReadCount, v)
 		}
 	}
 	setSum := func(item *SummaryByItem, sum uint64) {
@@ -123,6 +129,12 @@ func (dq *DefaultQuery) SummaryBy(startSecs, endSecs, windowSecs, top int, insta
 			item.NetworkBytesSum = sum
 		case OrderByLogicalIO:
 			item.LogicalIoBytesSum = sum
+		case OrderByLogicalRead:
+			item.LogicalReadBytesSum = sum
+		case OrderByLogicalWrite:
+			item.LogicalWriteBytesSum = sum
+		case OrderByBlockRead:
+			item.RocksdbBlockReadCountSum = sum
 		}
 	}
 
@@ -185,6 +197,12 @@ func (dq *DefaultQuery) Summary(startSecs, endSecs, windowSecs, top int, instanc
 		fillName = metricNameNetworkBytes
 	case OrderByLogicalIO:
 		fillName = metricNameLogicalIoBytes
+	case OrderByLogicalRead:
+		fillName = store.MetricNameLogicalReadBytes
+	case OrderByLogicalWrite:
+		fillName = store.MetricNameLogicalWriteBytes
+	case OrderByBlockRead:
+		fillName = store.MetricNameRocksdbBlockReadCount
 	}
 
 	var recordsResponse recordsMetricResp
@@ -227,6 +245,21 @@ func (dq *DefaultQuery) Summary(startSecs, endSecs, windowSecs, top int, instanc
 				plan.LogicalIoBytes = p.LogicalIoBytes
 				for _, v := range p.LogicalIoBytes {
 					sumItem.LogicalIoBytes += v
+				}
+			case OrderByLogicalRead:
+				plan.LogicalReadBytes = p.LogicalReadBytes
+				for _, v := range p.LogicalReadBytes {
+					sumItem.LogicalReadBytes += v
+				}
+			case OrderByLogicalWrite:
+				plan.LogicalWriteBytes = p.LogicalWriteBytes
+				for _, v := range p.LogicalWriteBytes {
+					sumItem.LogicalWriteBytes += v
+				}
+			case OrderByBlockRead:
+				plan.RocksdbBlockReadCount = p.RocksdbBlockReadCount
+				for _, v := range p.RocksdbBlockReadCount {
+					sumItem.RocksdbBlockReadCount += v
 				}
 			}
 			sumItem.Plans = append(sumItem.Plans, plan)
@@ -634,6 +667,12 @@ func (dq *DefaultQuery) fillText(name string, sqlGroups *[]sqlGroup, fill func(R
 				planItem.NetworkBytes = series.values
 			case metricNameLogicalIoBytes:
 				planItem.LogicalIoBytes = series.values
+			case store.MetricNameLogicalReadBytes:
+				planItem.LogicalReadBytes = series.values
+			case store.MetricNameLogicalWriteBytes:
+				planItem.LogicalWriteBytes = series.values
+			case store.MetricNameRocksdbBlockReadCount:
+				planItem.RocksdbBlockReadCount = series.values
 			case store.MetricNameReadRow:
 				planItem.ReadRows = series.values
 			case store.MetricNameReadIndex:
@@ -724,6 +763,12 @@ func buildOrderBySummaryQuery(orderBy string, windowSecs int, instance, instance
 			store.MetricNameLogicalReadBytes, instance, instanceType, windowSecs,
 			store.MetricNameLogicalWriteBytes, instance, instanceType, windowSecs,
 		), nil
+	case OrderByLogicalRead:
+		return fmt.Sprintf("sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])", store.MetricNameLogicalReadBytes, instance, instanceType, windowSecs), nil
+	case OrderByLogicalWrite:
+		return fmt.Sprintf("sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])", store.MetricNameLogicalWriteBytes, instance, instanceType, windowSecs), nil
+	case OrderByBlockRead:
+		return fmt.Sprintf("sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])", store.MetricNameRocksdbBlockReadCount, instance, instanceType, windowSecs), nil
 	default:
 		return "", fmt.Errorf("unknown orderBy: %s", orderBy)
 	}
@@ -751,6 +796,12 @@ func buildOrderBySummaryByQuery(orderBy string, windowSecs int, instance, instan
 				store.MetricNameRegionLogicalWriteBytes, instance, instanceType, windowSecs,
 				aggBy,
 			), nil
+		case OrderByLogicalRead:
+			return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameRegionLogicalReadBytes, instance, instanceType, windowSecs, aggBy), nil
+		case OrderByLogicalWrite:
+			return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameRegionLogicalWriteBytes, instance, instanceType, windowSecs, aggBy), nil
+		case OrderByBlockRead:
+			return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameRegionRocksdbBlockReadCount, instance, instanceType, windowSecs, aggBy), nil
 		default:
 			return "", fmt.Errorf("unknown orderBy: %s", orderBy)
 		}
@@ -779,6 +830,12 @@ func buildOrderBySummaryByQuery(orderBy string, windowSecs int, instance, instan
 			store.MetricNameLogicalWriteBytes, instance, instanceType, windowSecs,
 			aggBy,
 		), nil
+	case OrderByLogicalRead:
+		return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameLogicalReadBytes, instance, instanceType, windowSecs, aggBy), nil
+	case OrderByLogicalWrite:
+		return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameLogicalWriteBytes, instance, instanceType, windowSecs, aggBy), nil
+	case OrderByBlockRead:
+		return fmt.Sprintf("sum(sum_over_time(%s{instance=\"%s\", instance_type=\"%s\"}[%d])) by (%s)", store.MetricNameRocksdbBlockReadCount, instance, instanceType, windowSecs, aggBy), nil
 	default:
 		return "", fmt.Errorf("unknown orderBy: %s", orderBy)
 	}

--- a/component/topsql/query/default_query_test.go
+++ b/component/topsql/query/default_query_test.go
@@ -4,8 +4,62 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/pingcap/ng-monitoring/component/topsql/store"
+
 	"github.com/stretchr/testify/require"
 )
+
+func TestNormalizeOrderBy(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{" CPU ", OrderByCPU},
+		{"LogicalIO", OrderByLogicalIO},
+		{"LOGICAL_READ", OrderByLogicalRead},
+		{"logical_write", OrderByLogicalWrite},
+		{"BLOCK_READ", OrderByBlockRead},
+	}
+
+	for _, testCase := range testCases {
+		require.Equal(t, testCase.expected, NormalizeOrderBy(testCase.input))
+	}
+}
+
+func TestBuildDetailedIOSummaryQueries(t *testing.T) {
+	const (
+		instance     = "127.0.0.1:20160"
+		instanceType = "tikv"
+		windowSecs   = 60
+	)
+
+	testCases := []struct {
+		orderBy          string
+		metricName       string
+		regionMetricName string
+	}{
+		{OrderByLogicalRead, store.MetricNameLogicalReadBytes, store.MetricNameRegionLogicalReadBytes},
+		{OrderByLogicalWrite, store.MetricNameLogicalWriteBytes, store.MetricNameRegionLogicalWriteBytes},
+		{OrderByBlockRead, store.MetricNameRocksdbBlockReadCount, store.MetricNameRegionRocksdbBlockReadCount},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.orderBy, func(t *testing.T) {
+			query, err := buildOrderBySummaryQuery(testCase.orderBy, windowSecs, instance, instanceType)
+			require.NoError(t, err)
+			require.Equal(t, "sum_over_time("+testCase.metricName+"{instance=\"127.0.0.1:20160\", instance_type=\"tikv\"}[60])", query)
+
+			query, err = buildOrderBySummaryByQuery(testCase.orderBy, windowSecs, instance, instanceType, AggLevelTable)
+			require.NoError(t, err)
+			require.Equal(t, "sum(sum_over_time("+testCase.metricName+"{instance=\"127.0.0.1:20160\", instance_type=\"tikv\"}[60])) by (table)", query)
+
+			query, err = buildOrderBySummaryByQuery(testCase.orderBy, windowSecs, instance, instanceType, AggByRegionID)
+			require.NoError(t, err)
+			require.Equal(t, "sum(sum_over_time("+testCase.regionMetricName+"{instance=\"127.0.0.1:20160\", instance_type=\"tikv\"}[60])) by (region_id)", query)
+		})
+	}
+}
 
 func TestKeepTopK(t *testing.T) {
 	sqlGroups := []sqlGroup{{

--- a/component/topsql/query/model.go
+++ b/component/topsql/query/model.go
@@ -13,58 +13,73 @@ type RecordItem struct {
 }
 
 type RecordPlanItem struct {
-	PlanDigest       string   `json:"plan_digest"`
-	PlanText         string   `json:"plan_text"`
-	TimestampSec     []uint64 `json:"timestamp_sec"`
-	CPUTimeMs        []uint64 `json:"cpu_time_ms,omitempty"`
-	NetworkBytes     []uint64 `json:"network_bytes,omitempty"`
-	LogicalIoBytes   []uint64 `json:"logical_io_bytes,omitempty"`
-	ReadRows         []uint64 `json:"read_rows,omitempty"`
-	ReadIndexes      []uint64 `json:"read_indexes,omitempty"`
-	WriteRows        []uint64 `json:"write_rows,omitempty"`
-	WriteIndexes     []uint64 `json:"write_indexes,omitempty"`
-	SQLExecCount     []uint64 `json:"sql_exec_count,omitempty"`
-	SQLDurationSum   []uint64 `json:"sql_duration_sum,omitempty"`
-	SQLDurationCount []uint64 `json:"sql_duration_count,omitempty"`
+	PlanDigest            string   `json:"plan_digest"`
+	PlanText              string   `json:"plan_text"`
+	TimestampSec          []uint64 `json:"timestamp_sec"`
+	CPUTimeMs             []uint64 `json:"cpu_time_ms,omitempty"`
+	NetworkBytes          []uint64 `json:"network_bytes,omitempty"`
+	LogicalIoBytes        []uint64 `json:"logical_io_bytes,omitempty"`
+	LogicalReadBytes      []uint64 `json:"logical_read_bytes,omitempty"`
+	LogicalWriteBytes     []uint64 `json:"logical_write_bytes,omitempty"`
+	RocksdbBlockReadCount []uint64 `json:"rocksdb_block_read_count,omitempty"`
+	ReadRows              []uint64 `json:"read_rows,omitempty"`
+	ReadIndexes           []uint64 `json:"read_indexes,omitempty"`
+	WriteRows             []uint64 `json:"write_rows,omitempty"`
+	WriteIndexes          []uint64 `json:"write_indexes,omitempty"`
+	SQLExecCount          []uint64 `json:"sql_exec_count,omitempty"`
+	SQLDurationSum        []uint64 `json:"sql_duration_sum,omitempty"`
+	SQLDurationCount      []uint64 `json:"sql_duration_count,omitempty"`
 }
 
 type SummaryItem struct {
-	SQLDigest         string            `json:"sql_digest"`
-	SQLText           string            `json:"sql_text"`
-	IsOther           bool              `json:"is_other"`
-	CPUTimeMs         uint64            `json:"cpu_time_ms"`
-	ExecCountPerSec   float64           `json:"exec_count_per_sec"`
-	DurationPerExecMs float64           `json:"duration_per_exec_ms"`
-	ScanRecordsPerSec float64           `json:"scan_records_per_sec"`
-	ScanIndexesPerSec float64           `json:"scan_indexes_per_sec"`
-	NetworkBytes      uint64            `json:"network_bytes"`
-	LogicalIoBytes    uint64            `json:"logical_io_bytes"`
-	Plans             []SummaryPlanItem `json:"plans"`
+	SQLDigest             string            `json:"sql_digest"`
+	SQLText               string            `json:"sql_text"`
+	IsOther               bool              `json:"is_other"`
+	CPUTimeMs             uint64            `json:"cpu_time_ms"`
+	ExecCountPerSec       float64           `json:"exec_count_per_sec"`
+	DurationPerExecMs     float64           `json:"duration_per_exec_ms"`
+	ScanRecordsPerSec     float64           `json:"scan_records_per_sec"`
+	ScanIndexesPerSec     float64           `json:"scan_indexes_per_sec"`
+	NetworkBytes          uint64            `json:"network_bytes"`
+	LogicalIoBytes        uint64            `json:"logical_io_bytes"`
+	LogicalReadBytes      uint64            `json:"logical_read_bytes"`
+	LogicalWriteBytes     uint64            `json:"logical_write_bytes"`
+	RocksdbBlockReadCount uint64            `json:"rocksdb_block_read_count"`
+	Plans                 []SummaryPlanItem `json:"plans"`
 }
 
 type SummaryByItem struct {
-	Text              string   `json:"text"`
-	IsOther           bool     `json:"is_other"`
-	TimestampSec      []uint64 `json:"timestamp_sec"`
-	CPUTimeMs         []uint64 `json:"cpu_time_ms,omitempty"`
-	CPUTimeMsSum      uint64   `json:"cpu_time_ms_sum"`
-	NetworkBytes      []uint64 `json:"network_bytes,omitempty"`
-	NetworkBytesSum   uint64   `json:"network_bytes_sum"`
-	LogicalIoBytes    []uint64 `json:"logical_io_bytes,omitempty"`
-	LogicalIoBytesSum uint64   `json:"logical_io_bytes_sum"`
+	Text                     string   `json:"text"`
+	IsOther                  bool     `json:"is_other"`
+	TimestampSec             []uint64 `json:"timestamp_sec"`
+	CPUTimeMs                []uint64 `json:"cpu_time_ms,omitempty"`
+	CPUTimeMsSum             uint64   `json:"cpu_time_ms_sum"`
+	NetworkBytes             []uint64 `json:"network_bytes,omitempty"`
+	NetworkBytesSum          uint64   `json:"network_bytes_sum"`
+	LogicalIoBytes           []uint64 `json:"logical_io_bytes,omitempty"`
+	LogicalIoBytesSum        uint64   `json:"logical_io_bytes_sum"`
+	LogicalReadBytes         []uint64 `json:"logical_read_bytes,omitempty"`
+	LogicalReadBytesSum      uint64   `json:"logical_read_bytes_sum"`
+	LogicalWriteBytes        []uint64 `json:"logical_write_bytes,omitempty"`
+	LogicalWriteBytesSum     uint64   `json:"logical_write_bytes_sum"`
+	RocksdbBlockReadCount    []uint64 `json:"rocksdb_block_read_count,omitempty"`
+	RocksdbBlockReadCountSum uint64   `json:"rocksdb_block_read_count_sum"`
 }
 
 type SummaryPlanItem struct {
-	PlanDigest        string   `json:"plan_digest"`
-	PlanText          string   `json:"plan_text"`
-	TimestampSec      []uint64 `json:"timestamp_sec"`
-	CPUTimeMs         []uint64 `json:"cpu_time_ms,omitempty"`
-	ExecCountPerSec   float64  `json:"exec_count_per_sec"`
-	DurationPerExecMs float64  `json:"duration_per_exec_ms"`
-	ScanRecordsPerSec float64  `json:"scan_records_per_sec"`
-	ScanIndexesPerSec float64  `json:"scan_indexes_per_sec"`
-	NetworkBytes      []uint64 `json:"network_bytes"`
-	LogicalIoBytes    []uint64 `json:"logical_io_bytes"`
+	PlanDigest            string   `json:"plan_digest"`
+	PlanText              string   `json:"plan_text"`
+	TimestampSec          []uint64 `json:"timestamp_sec"`
+	CPUTimeMs             []uint64 `json:"cpu_time_ms,omitempty"`
+	ExecCountPerSec       float64  `json:"exec_count_per_sec"`
+	DurationPerExecMs     float64  `json:"duration_per_exec_ms"`
+	ScanRecordsPerSec     float64  `json:"scan_records_per_sec"`
+	ScanIndexesPerSec     float64  `json:"scan_indexes_per_sec"`
+	NetworkBytes          []uint64 `json:"network_bytes"`
+	LogicalIoBytes        []uint64 `json:"logical_io_bytes"`
+	LogicalReadBytes      []uint64 `json:"logical_read_bytes"`
+	LogicalWriteBytes     []uint64 `json:"logical_write_bytes"`
+	RocksdbBlockReadCount []uint64 `json:"rocksdb_block_read_count"`
 }
 
 type InstanceItem struct {

--- a/component/topsql/query/order_by.go
+++ b/component/topsql/query/order_by.go
@@ -3,9 +3,12 @@ package query
 import "strings"
 
 const (
-	OrderByCPU       = "cpu"
-	OrderByNetwork   = "network"
-	OrderByLogicalIO = "logical_io"
+	OrderByCPU          = "cpu"
+	OrderByNetwork      = "network"
+	OrderByLogicalIO    = "logical_io"
+	OrderByLogicalRead  = "logical_read"
+	OrderByLogicalWrite = "logical_write"
+	OrderByBlockRead    = "block_read"
 )
 
 const (

--- a/component/topsql/service/http.go
+++ b/component/topsql/service/http.go
@@ -101,11 +101,11 @@ func (s *Service) summaryHandler(c *gin.Context) {
 		orderBy = query.OrderByCPU
 	}
 	switch orderBy {
-	case query.OrderByCPU, query.OrderByNetwork, query.OrderByLogicalIO:
+	case query.OrderByCPU, query.OrderByNetwork, query.OrderByLogicalIO, query.OrderByLogicalRead, query.OrderByLogicalWrite, query.OrderByBlockRead:
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{
 			"status":  "error",
-			"message": "invalid orderBy, allowed: cpu, network, logical_io",
+			"message": "invalid orderBy, allowed: cpu, network, logical_io, logical_read, logical_write, block_read",
 		})
 		return
 	}

--- a/component/topsql/service/http_test.go
+++ b/component/topsql/service/http_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pingcap/ng-monitoring/component/topsql/query"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type summaryQueryStub struct {
+	orderBy string
+	calls   int
+}
+
+func (s *summaryQueryStub) Records(string, int, int, int, int, string, string, *[]query.RecordItem) error {
+	return nil
+}
+
+func (s *summaryQueryStub) Summary(_ int, _ int, _ int, _ int, _ string, _ string, _ *[]query.SummaryItem, orderBy string) error {
+	s.orderBy = orderBy
+	s.calls++
+	return nil
+}
+
+func (s *summaryQueryStub) SummaryBy(_ int, _ int, _ int, _ int, _ string, _ string, _ string, _ *[]query.SummaryByItem, orderBy string) error {
+	s.orderBy = orderBy
+	s.calls++
+	return nil
+}
+
+func (s *summaryQueryStub) Instances(int, int, *[]query.InstanceItem) error { return nil }
+func (s *summaryQueryStub) Close()                                          {}
+
+func TestSummaryHandlerOrderByCompatibility(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testCases := []struct {
+		name            string
+		parameter       string
+		expectedStatus  int
+		expectedOrderBy string
+		expectedCalls   int
+	}{
+		{"snake case parameter", "order_by=logical_read", http.StatusOK, query.OrderByLogicalRead, 1},
+		{"legacy camel case parameter", "orderBy=block_read", http.StatusOK, query.OrderByBlockRead, 1},
+		{"invalid value", "order_by=invalid", http.StatusBadRequest, "", 0},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stub := &summaryQueryStub{}
+			service := NewService(stub)
+			router := gin.New()
+			router.GET("/v1/summary", service.summaryHandler)
+
+			request := httptest.NewRequest(http.MethodGet, "/v1/summary?instance=127.0.0.1%3A20160&instance_type=tikv&start=1&end=2&"+testCase.parameter, nil)
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			require.Equal(t, testCase.expectedStatus, response.Code)
+			require.Equal(t, testCase.expectedCalls, stub.calls)
+			require.Equal(t, testCase.expectedOrderBy, stub.orderBy)
+		})
+	}
+}

--- a/component/topsql/store/default_store.go
+++ b/component/topsql/store/default_store.go
@@ -371,6 +371,18 @@ func rsMeteringProtoToMetrics(
 			Table:        tableName,
 		},
 	}
+	mRocksdbBlockReadCount := Metric{
+		Metric: recordTags{
+			Name:         MetricNameRocksdbBlockReadCount,
+			Instance:     instance,
+			InstanceType: instanceType,
+			SQLDigest:    sqlDigest,
+			PlanDigest:   planDigest,
+			DB:           schemaName,
+			Table:        tableName,
+		},
+	}
+	emitRocksdbBlockReadCount := hasRocksdbBlockReadCount(gr.GetItems())
 
 	for _, item := range gr.GetItems() {
 		tsMillis := item.TimestampSec * 1000
@@ -392,8 +404,16 @@ func rsMeteringProtoToMetrics(
 
 		mLogicalWrite.TimestampMs = append(mLogicalWrite.TimestampMs, tsMillis)
 		mLogicalWrite.Values = append(mLogicalWrite.Values, item.LogicalWriteBytes)
+
+		if emitRocksdbBlockReadCount {
+			mRocksdbBlockReadCount.TimestampMs = append(mRocksdbBlockReadCount.TimestampMs, tsMillis)
+			mRocksdbBlockReadCount.Values = append(mRocksdbBlockReadCount.Values, item.RocksdbBlockReadCount)
+		}
 	}
 	ms = append(ms, mCpu, mReadRow, mReadIndex, mWriteRow, mWriteIndex, mNetworkIn, mNetworkOut, mLogicalRead, mLogicalWrite)
+	if emitRocksdbBlockReadCount {
+		ms = append(ms, mRocksdbBlockReadCount)
+	}
 	return
 }
 
@@ -410,6 +430,8 @@ func rsMeteringRegionProtoToMetrics(instance, instanceType string, rr *rsmeterin
 	mNetworkOut := Metric{Metric: regionTags{Name: MetricNameRegionNetworkOutBytes, Instance: instance, InstanceType: instanceType, RegionID: regionID}}
 	mLogicalRead := Metric{Metric: regionTags{Name: MetricNameRegionLogicalReadBytes, Instance: instance, InstanceType: instanceType, RegionID: regionID}}
 	mLogicalWrite := Metric{Metric: regionTags{Name: MetricNameRegionLogicalWriteBytes, Instance: instance, InstanceType: instanceType, RegionID: regionID}}
+	mRocksdbBlockReadCount := Metric{Metric: regionTags{Name: MetricNameRegionRocksdbBlockReadCount, Instance: instance, InstanceType: instanceType, RegionID: regionID}}
+	emitRocksdbBlockReadCount := hasRocksdbBlockReadCount(rr.GetItems())
 
 	for _, item := range rr.GetItems() {
 		tsMillis := item.TimestampSec * 1000
@@ -434,9 +456,28 @@ func rsMeteringRegionProtoToMetrics(instance, instanceType string, rr *rsmeterin
 
 		mLogicalWrite.TimestampMs = append(mLogicalWrite.TimestampMs, tsMillis)
 		mLogicalWrite.Values = append(mLogicalWrite.Values, item.LogicalWriteBytes)
+
+		if emitRocksdbBlockReadCount {
+			mRocksdbBlockReadCount.TimestampMs = append(mRocksdbBlockReadCount.TimestampMs, tsMillis)
+			mRocksdbBlockReadCount.Values = append(mRocksdbBlockReadCount.Values, item.RocksdbBlockReadCount)
+		}
 	}
 
-	return []Metric{mCpu, mReadKeys, mWriteKeys, mNetworkIn, mNetworkOut, mLogicalRead, mLogicalWrite}
+	metrics := []Metric{mCpu, mReadKeys, mWriteKeys, mNetworkIn, mNetworkOut, mLogicalRead, mLogicalWrite}
+	if emitRocksdbBlockReadCount {
+		metrics = append(metrics, mRocksdbBlockReadCount)
+	}
+	return metrics
+}
+
+// Older TiKV versions decode the absent field as zero, so avoid creating zero-only series.
+func hasRocksdbBlockReadCount(items []*rsmetering.GroupTagRecordItem) bool {
+	for _, item := range items {
+		if item.GetRocksdbBlockReadCount() != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // appendMetricRowIndex only used in rsMeteringProtoToMetrics, just used to reduce repetition.

--- a/component/topsql/store/default_store_test.go
+++ b/component/topsql/store/default_store_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"testing"
+
+	rsmetering "github.com/pingcap/kvproto/pkg/resource_usage_agent"
+	"github.com/pingcap/tipb/go-tipb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRSMeteringProtoToMetricsBlockReadCount(t *testing.T) {
+	tagBytes, err := (&tipb.ResourceGroupTag{
+		SqlDigest:  []byte("sql-digest"),
+		PlanDigest: []byte("plan-digest"),
+		TableId:    1,
+	}).Marshal()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		values     []uint64
+		wantMetric bool
+	}{
+		{name: "all zero", values: []uint64{0, 0}, wantMetric: false},
+		{name: "contains nonzero", values: []uint64{0, 5}, wantMetric: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			items := make([]*rsmetering.GroupTagRecordItem, 0, len(testCase.values))
+			for i, value := range testCase.values {
+				items = append(items, &rsmetering.GroupTagRecordItem{
+					TimestampSec:          uint64(i + 1),
+					RocksdbBlockReadCount: value,
+				})
+			}
+
+			metrics, err := rsMeteringProtoToMetrics("tikv-0", "tikv", &rsmetering.ResourceUsageRecord{
+				RecordOneof: &rsmetering.ResourceUsageRecord_Record{Record: &rsmetering.GroupTagRecord{
+					ResourceGroupTag: tagBytes,
+					Items:            items,
+				}},
+			}, nil)
+			require.NoError(t, err)
+
+			metric := findMetric(metrics, MetricNameRocksdbBlockReadCount)
+			if !testCase.wantMetric {
+				require.Nil(t, metric)
+				require.Len(t, metrics, 9)
+				return
+			}
+			require.NotNil(t, metric)
+			require.Equal(t, []uint64{1000, 2000}, metric.TimestampMs)
+			require.Equal(t, testCase.values, metric.Values)
+			require.Len(t, metrics, 10)
+		})
+	}
+}
+
+func TestRSMeteringRegionProtoToMetricsBlockReadCount(t *testing.T) {
+	testCases := []struct {
+		name       string
+		values     []uint64
+		wantMetric bool
+	}{
+		{name: "all zero", values: []uint64{0, 0}, wantMetric: false},
+		{name: "contains nonzero", values: []uint64{0, 5}, wantMetric: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			items := make([]*rsmetering.GroupTagRecordItem, 0, len(testCase.values))
+			for i, value := range testCase.values {
+				items = append(items, &rsmetering.GroupTagRecordItem{
+					TimestampSec:          uint64(i + 1),
+					RocksdbBlockReadCount: value,
+				})
+			}
+
+			metrics := rsMeteringRegionProtoToMetrics("tikv-0", "tikv", &rsmetering.RegionRecord{
+				RegionId: 1,
+				Items:    items,
+			})
+
+			metric := findMetric(metrics, MetricNameRegionRocksdbBlockReadCount)
+			if !testCase.wantMetric {
+				require.Nil(t, metric)
+				require.Len(t, metrics, 7)
+				return
+			}
+			require.NotNil(t, metric)
+			require.Equal(t, []uint64{1000, 2000}, metric.TimestampMs)
+			require.Equal(t, testCase.values, metric.Values)
+			require.Len(t, metrics, 8)
+		})
+	}
+}
+
+func findMetric(metrics []Metric, name string) *Metric {
+	for i := range metrics {
+		switch tags := metrics[i].Metric.(type) {
+		case recordTags:
+			if tags.Name == name {
+				return &metrics[i]
+			}
+		case regionTags:
+			if tags.Name == name {
+				return &metrics[i]
+			}
+		}
+	}
+	return nil
+}

--- a/component/topsql/store/model.go
+++ b/component/topsql/store/model.go
@@ -13,18 +13,20 @@ const (
 	MetricNameSQLNetworkIn     = "sql_network_in_bytes"
 	MetricNameSQLNetworkOut    = "sql_network_out_bytes"
 
-	MetricNameNetworkInBytes    = "network_in_bytes"
-	MetricNameNetworkOutBytes   = "network_out_bytes"
-	MetricNameLogicalReadBytes  = "logical_read_bytes"
-	MetricNameLogicalWriteBytes = "logical_write_bytes"
+	MetricNameNetworkInBytes        = "network_in_bytes"
+	MetricNameNetworkOutBytes       = "network_out_bytes"
+	MetricNameLogicalReadBytes      = "logical_read_bytes"
+	MetricNameLogicalWriteBytes     = "logical_write_bytes"
+	MetricNameRocksdbBlockReadCount = "rocksdb_block_read_count"
 
-	MetricNameRegionCPUTime           = "region_cpu_time"
-	MetricNameRegionReadKeys          = "region_read_keys"
-	MetricNameRegionWriteKeys         = "region_write_keys"
-	MetricNameRegionNetworkInBytes    = "region_network_in_bytes"
-	MetricNameRegionNetworkOutBytes   = "region_network_out_bytes"
-	MetricNameRegionLogicalReadBytes  = "region_logical_read_bytes"
-	MetricNameRegionLogicalWriteBytes = "region_logical_write_bytes"
+	MetricNameRegionCPUTime               = "region_cpu_time"
+	MetricNameRegionReadKeys              = "region_read_keys"
+	MetricNameRegionWriteKeys             = "region_write_keys"
+	MetricNameRegionNetworkInBytes        = "region_network_in_bytes"
+	MetricNameRegionNetworkOutBytes       = "region_network_out_bytes"
+	MetricNameRegionLogicalReadBytes      = "region_logical_read_bytes"
+	MetricNameRegionLogicalWriteBytes     = "region_logical_write_bytes"
+	MetricNameRegionRocksdbBlockReadCount = "region_rocksdb_block_read_count"
 )
 
 type Metric struct {

--- a/component/topsql/topsql_test.go
+++ b/component/topsql/topsql_test.go
@@ -1178,11 +1178,11 @@ func (s *testTopSQLSuite) TestTiKVSummaryOrderByNetwork() {
 	s.Greater(other.NetworkBytes, uint64(0))
 }
 
-func (s *testTopSQLSuite) TestTiKVSummaryOrderByLogicalIO() {
+func (s *testTopSQLSuite) TestTiKVSummaryOrderByResourceDimensions() {
 	instance := "127.0.0.1:30000"
 	tikvInstanceType := "tikv"
 
-	mkRecord := func(sqlDigest string, cpuMs uint32, logicalRead, logicalWrite uint64) *rsmetering.ResourceUsageRecord {
+	mkRecord := func(sqlDigest string, cpuMs uint32, logicalRead, logicalWrite, blockRead uint64) *rsmetering.ResourceUsageRecord {
 		tag := tipb.ResourceGroupTag{
 			SqlDigest:  []byte(sqlDigest),
 			PlanDigest: []byte("plan-0"),
@@ -1192,10 +1192,11 @@ func (s *testTopSQLSuite) TestTiKVSummaryOrderByLogicalIO() {
 		s.NoError(err)
 
 		items := []*rsmetering.GroupTagRecordItem{{
-			TimestampSec:      testBaseTs,
-			CpuTimeMs:         cpuMs,
-			LogicalReadBytes:  logicalRead,
-			LogicalWriteBytes: logicalWrite,
+			TimestampSec:          testBaseTs,
+			CpuTimeMs:             cpuMs,
+			LogicalReadBytes:      logicalRead,
+			LogicalWriteBytes:     logicalWrite,
+			RocksdbBlockReadCount: blockRead,
 		}}
 
 		return &rsmetering.ResourceUsageRecord{
@@ -1207,9 +1208,9 @@ func (s *testTopSQLSuite) TestTiKVSummaryOrderByLogicalIO() {
 	}
 
 	// sql-logic-hi: low cpu, high logical IO
-	s.NoError(s.ds.ResourceMeteringRecord(instance, tikvInstanceType, mkRecord("sql-logic-hi", 1, 1000, 1000), nil))
+	s.NoError(s.ds.ResourceMeteringRecord(instance, tikvInstanceType, mkRecord("sql-logic-hi", 1, 1000, 1000, 1), nil))
 	// sql-cpu-hi: high cpu, low logical IO
-	s.NoError(s.ds.ResourceMeteringRecord(instance, tikvInstanceType, mkRecord("sql-cpu-hi", 1000, 1, 1), nil))
+	s.NoError(s.ds.ResourceMeteringRecord(instance, tikvInstanceType, mkRecord("sql-cpu-hi", 1000, 1, 1, 1000), nil))
 
 	vmstorage.Storage.DebugFlush()
 
@@ -1232,6 +1233,29 @@ func (s *testTopSQLSuite) TestTiKVSummaryOrderByLogicalIO() {
 	s.Require().NotNil(other)
 	s.True(other.IsOther)
 	s.Greater(other.LogicalIoBytes, uint64(0))
+
+	assertTop := func(orderBy, expectedDigest string, value func(*query.SummaryItem) uint64) {
+		var items []query.SummaryItem
+		s.NoError(s.dq.Summary(int(testBaseTs), int(testBaseTs+10), 10, 1, instance, tikvInstanceType, &items, orderBy))
+		s.Require().Len(items, 2)
+		for i := range items {
+			if !items[i].IsOther {
+				s.Equal(expectedDigest, items[i].SQLDigest)
+				s.Greater(value(&items[i]), uint64(0))
+				return
+			}
+		}
+		s.Fail("top resource record not found")
+	}
+	assertTop(query.OrderByLogicalRead, hex.EncodeToString([]byte("sql-logic-hi")), func(item *query.SummaryItem) uint64 {
+		return item.LogicalReadBytes
+	})
+	assertTop(query.OrderByLogicalWrite, hex.EncodeToString([]byte("sql-logic-hi")), func(item *query.SummaryItem) uint64 {
+		return item.LogicalWriteBytes
+	})
+	assertTop(query.OrderByBlockRead, hex.EncodeToString([]byte("sql-cpu-hi")), func(item *query.SummaryItem) uint64 {
+		return item.RocksdbBlockReadCount
+	})
 }
 
 func (s *testTopSQLSuite) TestTiKVSummaryByRegion() {
@@ -1241,8 +1265,11 @@ func (s *testTopSQLSuite) TestTiKVSummaryByRegion() {
 	rr := &rsmetering.RegionRecord{
 		RegionId: 123,
 		Items: []*rsmetering.GroupTagRecordItem{{
-			TimestampSec: testBaseTs,
-			CpuTimeMs:    10,
+			TimestampSec:          testBaseTs,
+			CpuTimeMs:             10,
+			LogicalReadBytes:      20,
+			LogicalWriteBytes:     30,
+			RocksdbBlockReadCount: 40,
 		}},
 	}
 	record := &rsmetering.ResourceUsageRecord{
@@ -1251,18 +1278,44 @@ func (s *testTopSQLSuite) TestTiKVSummaryByRegion() {
 	s.NoError(s.ds.ResourceMeteringRecord(instance, tikvInstanceType, record, nil))
 	vmstorage.Storage.DebugFlush()
 
-	var res []query.SummaryByItem
-	err := s.dq.SummaryBy(int(testBaseTs), int(testBaseTs+10), 10, 5, instance, tikvInstanceType, query.AggByRegionID, &res, query.OrderByCPU)
-	s.NoError(err)
-	s.Require().NotEmpty(res)
-	found := false
-	for _, item := range res {
-		if item.Text == "123" {
-			found = true
-			s.Greater(item.CPUTimeMsSum, uint64(0))
+	assertRegionMetric := func(orderBy string, values func(query.SummaryByItem) []uint64, total func(query.SummaryByItem) uint64) {
+		var res []query.SummaryByItem
+		err := s.dq.SummaryBy(int(testBaseTs), int(testBaseTs+10), 10, 5, instance, tikvInstanceType, query.AggByRegionID, &res, orderBy)
+		s.NoError(err)
+		s.Require().NotEmpty(res)
+
+		for _, item := range res {
+			if item.Text != "123" {
+				continue
+			}
+			s.Require().NotEmpty(values(item))
+			s.Greater(total(item), uint64(0))
+			s.Equal(sum(values(item)), total(item))
+			return
 		}
+		s.Fail("region resource record not found", "orderBy: %s", orderBy)
 	}
-	s.True(found)
+
+	assertRegionMetric(query.OrderByCPU, func(item query.SummaryByItem) []uint64 {
+		return item.CPUTimeMs
+	}, func(item query.SummaryByItem) uint64 {
+		return item.CPUTimeMsSum
+	})
+	assertRegionMetric(query.OrderByLogicalRead, func(item query.SummaryByItem) []uint64 {
+		return item.LogicalReadBytes
+	}, func(item query.SummaryByItem) uint64 {
+		return item.LogicalReadBytesSum
+	})
+	assertRegionMetric(query.OrderByLogicalWrite, func(item query.SummaryByItem) []uint64 {
+		return item.LogicalWriteBytes
+	}, func(item query.SummaryByItem) uint64 {
+		return item.LogicalWriteBytesSum
+	})
+	assertRegionMetric(query.OrderByBlockRead, func(item query.SummaryByItem) []uint64 {
+		return item.RocksdbBlockReadCount
+	}, func(item query.SummaryByItem) uint64 {
+		return item.RocksdbBlockReadCountSum
+	})
 }
 
 func (s *testTopSQLSuite) sortSummary(res []query.SummaryItem) {

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/pprof v0.0.0-20241001023024-f4c0cfd0cf1d
 	github.com/mattn/go-sqlite3 v1.14.24
-<<<<<<< HEAD
-	github.com/pingcap/kvproto v0.0.0-20260302041553-bdcab1db9bef
-=======
 	github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/tidb v1.1.0-beta.0.20260306172441-ffe64946248c
 	github.com/pingcap/tidb-dashboard v0.0.0-20230222090907-5530ca41768d
@@ -38,16 +34,9 @@ require (
 	go.etcd.io/etcd/tests/v3 v3.5.12
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
-<<<<<<< HEAD
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.56.0
 	google.golang.org/grpc v1.82.1
-=======
-	go.uber.org/zap v1.27.1
-	golang.org/x/net v0.56.0
-	google.golang.org/grpc v1.82.1
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 )
 
 require (
@@ -174,31 +163,18 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/arch v0.12.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
-<<<<<<< HEAD
 	golang.org/x/exp v0.0.0-20251002181428-27f1f14c8bb9 // indirect
 	golang.org/x/image v0.43.0 // indirect
-=======
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/image v0.18.0 // indirect
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-<<<<<<< HEAD
 	google.golang.org/genproto v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-=======
-	google.golang.org/api v0.249.0 // indirect
-	google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
@@ -206,8 +182,6 @@ require (
 )
 
 replace github.com/pingcap/tidb/pkg/parser => github.com/pingcap/tidb/pkg/parser v0.0.0-20260306172441-ffe64946248c
-
-replace github.com/pingcap/kvproto => github.com/pingcap/kvproto v0.0.0-20260226023611-e75b531a1914
 
 replace github.com/genjidb/genji/engine/badgerengine => github.com/crazycs520/genji/engine/badgerengine v0.12.1-0.20220328082424-727a2d089bde
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,11 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/pprof v0.0.0-20241001023024-f4c0cfd0cf1d
 	github.com/mattn/go-sqlite3 v1.14.24
+<<<<<<< HEAD
 	github.com/pingcap/kvproto v0.0.0-20260302041553-bdcab1db9bef
+=======
+	github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/tidb v1.1.0-beta.0.20260306172441-ffe64946248c
 	github.com/pingcap/tidb-dashboard v0.0.0-20230222090907-5530ca41768d
@@ -34,9 +38,16 @@ require (
 	go.etcd.io/etcd/tests/v3 v3.5.12
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.3.0
+<<<<<<< HEAD
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.56.0
 	google.golang.org/grpc v1.82.1
+=======
+	go.uber.org/zap v1.27.1
+	golang.org/x/net v0.56.0
+	google.golang.org/grpc v1.82.1
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 )
 
 require (
@@ -124,8 +135,8 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/client-go/v2 v2.0.8-0.20260209125252-1fd09ba3ef10 // indirect
-	github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9 // indirect
+	github.com/tikv/client-go/v2 v2.0.8-0.20260811081704-86fe4e58c8a7 // indirect
+	github.com/tikv/pd/client v0.0.0-20260805103528-afa43111d149 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
@@ -163,18 +174,31 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/arch v0.12.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
+<<<<<<< HEAD
 	golang.org/x/exp v0.0.0-20251002181428-27f1f14c8bb9 // indirect
 	golang.org/x/image v0.43.0 // indirect
+=======
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
+	golang.org/x/image v0.18.0 // indirect
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
+<<<<<<< HEAD
 	google.golang.org/genproto v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+=======
+	google.golang.org/api v0.249.0 // indirect
+	google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
-=======
-cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
-cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -823,15 +818,6 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-<<<<<<< HEAD
-=======
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0/go.mod h1:IA1C1U7jO/ENqm/vhi7V9YYpBsp+IMyqNrEN94N7tVc=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41G2q8KWhVGkNiY=
 github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
@@ -905,7 +891,6 @@ github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJ
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-<<<<<<< HEAD
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -920,10 +905,6 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230428030218-4003588d1b74/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-=======
-github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
-github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
@@ -972,7 +953,6 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-<<<<<<< HEAD
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
@@ -991,18 +971,6 @@ github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6Ni
 github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-=======
-github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
-github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
-github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
-github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
-github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
-github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
-github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -1023,7 +991,6 @@ github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
-<<<<<<< HEAD
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
@@ -1032,10 +999,6 @@ github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmn
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-=======
-github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
-github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
@@ -1357,14 +1320,10 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-<<<<<<< HEAD
 github.com/pingcap/kvproto v0.0.0-20260226023611-e75b531a1914 h1:Bc12etSkj719c5I01LWtT62tU+dObE9IphjJAG+ZWIg=
 github.com/pingcap/kvproto v0.0.0-20260226023611-e75b531a1914/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-=======
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9 h1:xN0vwFIrHaIsb4oX5qU80qAjAz2ctgx++9JvD/+hwjM=
 github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
@@ -1449,11 +1408,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-<<<<<<< HEAD
-=======
-github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
-github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -1477,19 +1431,14 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-<<<<<<< HEAD
 github.com/tikv/client-go/v2 v2.0.8-0.20260209125252-1fd09ba3ef10 h1:IN8USSwL3oqUXXcBU6tC5W+sMxIyzEOuIDbBScuF2gA=
 github.com/tikv/client-go/v2 v2.0.8-0.20260209125252-1fd09ba3ef10/go.mod h1:4jHqtFu0MeXVYFbka4yTZRxV/nR1Jw46hkyD5qhxi7s=
-github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9 h1:3rE2zAKWw8LEnCkybQEyrOIi/S2YESGDSgs7ae3DlLI=
-github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9/go.mod h1:JsDKQ70x0OWIhTj0SCuwiRjwPEC+d+Z8WV+QUXNKBSo=
-=======
 github.com/tikv/client-go/v2 v2.0.8-0.20260811081704-86fe4e58c8a7 h1:yHuJXYEmTFzQnOF54auReTGQ2+xKBoB4t8sNzQ8nvXQ=
 github.com/tikv/client-go/v2 v2.0.8-0.20260811081704-86fe4e58c8a7/go.mod h1:Bid1lF4a8ESuhOH7CeVobOrWxUJvtg16ZLBxogNuZWk=
+github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9 h1:3rE2zAKWw8LEnCkybQEyrOIi/S2YESGDSgs7ae3DlLI=
+github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9/go.mod h1:JsDKQ70x0OWIhTj0SCuwiRjwPEC+d+Z8WV+QUXNKBSo=
 github.com/tikv/pd/client v0.0.0-20260805103528-afa43111d149 h1:q5NgKsvuOdEHspG/pZEpKhWlPLrIfmO8P/lDFjTEdok=
 github.com/tikv/pd/client v0.0.0-20260805103528-afa43111d149/go.mod h1:sfdha4LXeUkSs2Z7N5jLzDEtm0GE7x+Glm2pW3UgEpA=
-github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
-github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
@@ -1545,11 +1494,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-<<<<<<< HEAD
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
 go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
@@ -1580,17 +1526,8 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-<<<<<<< HEAD
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0/go.mod h1:rg+RlpR5dKwaS95IyyZqj5Wd4E13lk/msnTS0Xl9lJM=
-=======
-go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
-go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0 h1:PzIubN4/sjByhDRHLviCjJuweBXWFZWhghjg7cS28+M=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0/go.mod h1:Ct6zzQEuGK3WpJs2n4dn+wfJYzd/+hNnxMRTWjGn30M=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.22.0 h1:9M3+rhx7kZCIQQhQRYaZCdNu1V73tm4TvXs2ntl98C4=
@@ -1605,12 +1542,9 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-<<<<<<< HEAD
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.opentelemetry.io/proto/otlp v1.1.0 h1:2Di21piLrCqJ3U3eXGCTPHE9R8Nh+0uglSnOyxikMeI=
 go.opentelemetry.io/proto/otlp v1.1.0/go.mod h1:GpBHCBWiqvVLDqmHZsoMM3C5ySeKTC7ej/RNTae6MdY=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -1664,11 +1598,8 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
-<<<<<<< HEAD
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1803,7 +1734,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-<<<<<<< HEAD
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -1831,8 +1761,6 @@ golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4
 golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
 golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
 golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1851,11 +1779,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-<<<<<<< HEAD
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1951,12 +1876,6 @@ golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-<<<<<<< HEAD
-=======
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1973,12 +1892,7 @@ golang.org/x/term v0.9.0/go.mod h1:M6DEAAIenWoTxdKrOltXcmDY3rSplQUkrvaDU5FcQyo=
 golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
 golang.org/x/term v0.11.0/go.mod h1:zC9APTIj3jG3FdV/Ons+XE1riIZXG4aZ4GTHiPZJPIU=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
-<<<<<<< HEAD
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-=======
-golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
-golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -2000,14 +1914,11 @@ golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
 golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
-<<<<<<< HEAD
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
@@ -2079,20 +1990,16 @@ golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-<<<<<<< HEAD
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
 golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-<<<<<<< HEAD
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -2171,12 +2078,6 @@ google.golang.org/api v0.125.0/go.mod h1:mBwVAtz+87bEN6CbA1GtZPDOqY2R5ONPqJeIlvy
 google.golang.org/api v0.126.0/go.mod h1:mBwVAtz+87bEN6CbA1GtZPDOqY2R5ONPqJeIlvyo4Aw=
 google.golang.org/api v0.128.0/go.mod h1:Y611qgqaE92On/7g65MQgxYul3c0rEB894kniWLY750=
 google.golang.org/api v0.139.0/go.mod h1:CVagp6Eekz9CjGZ718Z+sloknzkDJE7Vc1Ckj9+viBk=
-=======
-gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
-gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/api v0.249.0 h1:0VrsWAKzIZi058aeq+I86uIXbNhm9GxSHpbmZ92a38w=
-google.golang.org/api v0.249.0/go.mod h1:dGk9qyI0UYPwO/cjt2q06LG/EhUpwZGdAbYF14wHHrQ=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -2211,7 +2112,6 @@ google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-<<<<<<< HEAD
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2367,15 +2267,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b/go.mod h1:swOH3j0KzcDDgGUWr+SNpyTen5YrXjS3eyPzFYKc6lc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-=======
-google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 h1:LvZVVaPE0JSqL+ZWb6ErZfnEOKIqqFWUJE2D0fObSmc=
-google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9/go.mod h1:QFOrLhdAe2PsTp3vQY4quuLKTi9j3XG3r6JPPaw7MSc=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -2392,7 +2283,6 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-<<<<<<< HEAD
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
@@ -2428,10 +2318,6 @@ google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9Y
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-=======
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/grpc/examples v0.0.0-20231221225426-4f03f3ff32c9 h1:ATnmU8nL2NfIyTSiBvJVDIDIr3qBmeW+c7z7XU21eWs=
 google.golang.org/grpc/examples v0.0.0-20231221225426-4f03f3ff32c9/go.mod h1:j5uROIAAgi3YmtiETMt1LW0d/lHqQ7wwrIY4uGRXLQ4=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -2444,7 +2330,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-<<<<<<< HEAD
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -2453,8 +2338,6 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-=======
->>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
+<<<<<<< HEAD
+=======
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -818,6 +823,15 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+<<<<<<< HEAD
+=======
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0/go.mod h1:IA1C1U7jO/ENqm/vhi7V9YYpBsp+IMyqNrEN94N7tVc=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41G2q8KWhVGkNiY=
 github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
@@ -891,6 +905,7 @@ github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJ
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+<<<<<<< HEAD
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -905,6 +920,10 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230428030218-4003588d1b74/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+=======
+github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
+github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
@@ -953,6 +972,7 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+<<<<<<< HEAD
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
@@ -971,6 +991,18 @@ github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6Ni
 github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+=======
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
+github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
+github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
+github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -991,6 +1023,7 @@ github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+<<<<<<< HEAD
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
@@ -999,6 +1032,10 @@ github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmn
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+=======
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
@@ -1320,8 +1357,14 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
+<<<<<<< HEAD
 github.com/pingcap/kvproto v0.0.0-20260226023611-e75b531a1914 h1:Bc12etSkj719c5I01LWtT62tU+dObE9IphjJAG+ZWIg=
 github.com/pingcap/kvproto v0.0.0-20260226023611-e75b531a1914/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+=======
+github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
+github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9 h1:xN0vwFIrHaIsb4oX5qU80qAjAz2ctgx++9JvD/+hwjM=
+github.com/pingcap/kvproto v0.0.0-20260813070037-af1ad1bef5b9/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
@@ -1406,6 +1449,11 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+<<<<<<< HEAD
+=======
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -1429,10 +1477,19 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
+<<<<<<< HEAD
 github.com/tikv/client-go/v2 v2.0.8-0.20260209125252-1fd09ba3ef10 h1:IN8USSwL3oqUXXcBU6tC5W+sMxIyzEOuIDbBScuF2gA=
 github.com/tikv/client-go/v2 v2.0.8-0.20260209125252-1fd09ba3ef10/go.mod h1:4jHqtFu0MeXVYFbka4yTZRxV/nR1Jw46hkyD5qhxi7s=
 github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9 h1:3rE2zAKWw8LEnCkybQEyrOIi/S2YESGDSgs7ae3DlLI=
 github.com/tikv/pd/client v0.0.0-20260122075414-848dd85011e9/go.mod h1:JsDKQ70x0OWIhTj0SCuwiRjwPEC+d+Z8WV+QUXNKBSo=
+=======
+github.com/tikv/client-go/v2 v2.0.8-0.20260811081704-86fe4e58c8a7 h1:yHuJXYEmTFzQnOF54auReTGQ2+xKBoB4t8sNzQ8nvXQ=
+github.com/tikv/client-go/v2 v2.0.8-0.20260811081704-86fe4e58c8a7/go.mod h1:Bid1lF4a8ESuhOH7CeVobOrWxUJvtg16ZLBxogNuZWk=
+github.com/tikv/pd/client v0.0.0-20260805103528-afa43111d149 h1:q5NgKsvuOdEHspG/pZEpKhWlPLrIfmO8P/lDFjTEdok=
+github.com/tikv/pd/client v0.0.0-20260805103528-afa43111d149/go.mod h1:sfdha4LXeUkSs2Z7N5jLzDEtm0GE7x+Glm2pW3UgEpA=
+github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
+github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
@@ -1488,8 +1545,11 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+<<<<<<< HEAD
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
 go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
@@ -1520,8 +1580,17 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+<<<<<<< HEAD
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0/go.mod h1:rg+RlpR5dKwaS95IyyZqj5Wd4E13lk/msnTS0Xl9lJM=
+=======
+go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
+go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0 h1:PzIubN4/sjByhDRHLviCjJuweBXWFZWhghjg7cS28+M=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0/go.mod h1:Ct6zzQEuGK3WpJs2n4dn+wfJYzd/+hNnxMRTWjGn30M=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.22.0 h1:9M3+rhx7kZCIQQhQRYaZCdNu1V73tm4TvXs2ntl98C4=
@@ -1536,9 +1605,12 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+<<<<<<< HEAD
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 go.opentelemetry.io/proto/otlp v1.1.0 h1:2Di21piLrCqJ3U3eXGCTPHE9R8Nh+0uglSnOyxikMeI=
 go.opentelemetry.io/proto/otlp v1.1.0/go.mod h1:GpBHCBWiqvVLDqmHZsoMM3C5ySeKTC7ej/RNTae6MdY=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -1592,8 +1664,11 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+<<<<<<< HEAD
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1728,6 +1803,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+<<<<<<< HEAD
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -1755,6 +1831,8 @@ golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4
 golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
 golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
 golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1773,8 +1851,11 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+<<<<<<< HEAD
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1870,6 +1951,12 @@ golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+<<<<<<< HEAD
+=======
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1886,7 +1973,12 @@ golang.org/x/term v0.9.0/go.mod h1:M6DEAAIenWoTxdKrOltXcmDY3rSplQUkrvaDU5FcQyo=
 golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
 golang.org/x/term v0.11.0/go.mod h1:zC9APTIj3jG3FdV/Ons+XE1riIZXG4aZ4GTHiPZJPIU=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
+<<<<<<< HEAD
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+=======
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -1908,11 +2000,14 @@ golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
 golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+<<<<<<< HEAD
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
@@ -1984,16 +2079,20 @@ golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+<<<<<<< HEAD
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
 golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+<<<<<<< HEAD
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -2072,6 +2171,12 @@ google.golang.org/api v0.125.0/go.mod h1:mBwVAtz+87bEN6CbA1GtZPDOqY2R5ONPqJeIlvy
 google.golang.org/api v0.126.0/go.mod h1:mBwVAtz+87bEN6CbA1GtZPDOqY2R5ONPqJeIlvyo4Aw=
 google.golang.org/api v0.128.0/go.mod h1:Y611qgqaE92On/7g65MQgxYul3c0rEB894kniWLY750=
 google.golang.org/api v0.139.0/go.mod h1:CVagp6Eekz9CjGZ718Z+sloknzkDJE7Vc1Ckj9+viBk=
+=======
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
+google.golang.org/api v0.249.0 h1:0VrsWAKzIZi058aeq+I86uIXbNhm9GxSHpbmZ92a38w=
+google.golang.org/api v0.249.0/go.mod h1:dGk9qyI0UYPwO/cjt2q06LG/EhUpwZGdAbYF14wHHrQ=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -2106,6 +2211,7 @@ google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+<<<<<<< HEAD
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2261,6 +2367,15 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b/go.mod h1:swOH3j0KzcDDgGUWr+SNpyTen5YrXjS3eyPzFYKc6lc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+=======
+google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 h1:LvZVVaPE0JSqL+ZWb6ErZfnEOKIqqFWUJE2D0fObSmc=
+google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9/go.mod h1:QFOrLhdAe2PsTp3vQY4quuLKTi9j3XG3r6JPPaw7MSc=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
+google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -2277,6 +2392,7 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
+<<<<<<< HEAD
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
@@ -2312,6 +2428,10 @@ google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9Y
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+=======
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/grpc/examples v0.0.0-20231221225426-4f03f3ff32c9 h1:ATnmU8nL2NfIyTSiBvJVDIDIr3qBmeW+c7z7XU21eWs=
 google.golang.org/grpc/examples v0.0.0-20231221225426-4f03f3ff32c9/go.mod h1:j5uROIAAgi3YmtiETMt1LW0d/lHqQ7wwrIY4uGRXLQ4=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -2324,6 +2444,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+<<<<<<< HEAD
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -2332,6 +2453,8 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+=======
+>>>>>>> 0592ffe (topsql: support detailed IO dimensions (#355))
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This is a manual backport of #355 to release-8.5.

The automated backport #361 contained conflict markers in go.mod and go.sum. This branch resolves them by preserving the release-8.5 dependency baseline while upgrading kvproto, PD client, and client-go to the compatible revisions required by #355.

Issue Number: ref #356

Related changes:
- Source PR: #355
- TiKV: https://github.com/tikv/tikv/pull/19953
- TiDB Dashboard: https://github.com/pingcap/tidb-dashboard/pull/1925

Validation:
- `GOTOOLCHAIN=go1.25.12 go test -mod=readonly ./component/topsql/store ./component/topsql/query ./component/topsql/service ./component/topsql/codec/plan ./component/topsql/subscriber ./component/topsql`